### PR TITLE
docs(governance): add doctrine v0.2.0 PR-only release playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,4 @@ If you use FrameKit in your project, please mention FrameKit and credit George G
 - [Architecture](docs/architecture.md)
 - [Selective Linking](docs/selective_linking.md)
 - [Doctrine Snapshot](docs/doctrine/README.md)
+- [Release Workflow Playbook](docs/doctrine/release-playbook.md)

--- a/docs/doctrine/README.md
+++ b/docs/doctrine/README.md
@@ -6,6 +6,12 @@ This folder contains a local doctrine snapshot copied from the Doctrine reposito
 
 The canonical source remains the Doctrine repository.
 
+## Local Governance Docs
+
+- [Repository Management](repo-management.md)
+- [Release Workflow Playbook](release-playbook.md)
+- [Doctrine Governance](doctrine-governance.md)
+
 ## Refresh
 
 Re-run bootstrap when doctrine updates are needed.

--- a/docs/doctrine/release-playbook.md
+++ b/docs/doctrine/release-playbook.md
@@ -1,0 +1,109 @@
+# Release Workflow Playbook
+
+Status: Stable  
+Last Reviewed: 2026-03-04
+
+## Purpose
+
+Operational runbook for PR-only branch governance under Doctrine v0.2.0.
+
+## Branch Strategy
+
+- `feature/*` and `fix/*` branches merge into `develop` via PR.
+- `release/*` branches are used for release stabilization and promotion.
+- Promote to stable with PR `release/* -> master`.
+- Back-propagate with PR `release/* -> develop` after `master` merge when release-only commits are not already present in `develop`.
+- No direct pushes to protected branches.
+
+## Required Checks
+
+Current required status checks are:
+
+- `develop`: `smoke`, `pr-title`, `issue-link`
+- `master`: `smoke`, `pr-title`, `issue-link`, `master-promotion`
+
+Workflow names backing these checks:
+
+- `CI (C++ / CMake)` -> `smoke`
+- `CI (PR Title)` -> `pr-title`
+- `CI (Issue Link)` -> `issue-link`
+- `CI (Master Promotion)` -> `master-promotion`
+
+## Pre-Flight Checklist
+
+Before creating a release branch:
+
+- `develop` is green and up to date with intended integration changes.
+- Release scope and deferred items are documented.
+- Signed commits are enabled locally and required remotely.
+- Branch protections confirm PR-only merges on `master` and `develop`.
+
+## Release Promotion Checklist
+
+1. Create release branch from `develop`.
+2. Apply stabilization updates only (docs, release notes, version and packaging touches, final fixes).
+3. Open PR `release/* -> master`.
+4. Ensure all required checks pass:
+   - `smoke`
+   - `pr-title`
+   - `issue-link`
+   - `master-promotion`
+5. Merge PR after checks are green.
+6. Create signed tag on `master` and push tag.
+
+## Post-Merge Checklist
+
+1. If needed, open PR `release/* -> develop` to back-propagate release-only commits.
+2. Verify `develop` and `master` both contain release stabilization commits.
+3. Delete merged `release/*` branch.
+4. Record release evidence links in the release issue/checklist.
+
+## Failure and Recovery
+
+### `master-promotion` check failed
+
+Cause: PR into `master` does not come from `release/*`.
+
+Recovery:
+
+1. Close the invalid PR.
+2. Create a `release/*` branch from `develop`.
+3. Re-open promotion PR from `release/*` to `master`.
+
+### Required check missing or pending
+
+Cause: Workflow not active, check name drift, or queued jobs.
+
+Recovery:
+
+1. Confirm workflow files exist in `.github/workflows/` and are active in GitHub Actions.
+2. Confirm branch protection required check names exactly match:
+   - `smoke`
+   - `pr-title`
+   - `issue-link`
+   - `master-promotion` (for `master`)
+3. Re-run workflows or update branch protection check list to match canonical names.
+
+## Emergency Hotfix
+
+- Use `release/hotfix-*` branch naming.
+- Merge `release/hotfix-* -> master` first.
+- Merge same branch into `develop` immediately after.
+- Preserve signed-commit and signed-tag requirements.
+
+## Quick Verification Commands
+
+```bash
+# Required checks on master
+
+gh api repos/<org>/<repo>/branches/master/protection --jq '.required_status_checks.contexts'
+
+# Required checks on develop
+
+gh api repos/<org>/<repo>/branches/develop/protection --jq '.required_status_checks.contexts'
+
+# Admin bypass disabled
+
+gh api repos/<org>/<repo>/branches/master/protection --jq '.enforce_admins.enabled'
+gh api repos/<org>/<repo>/branches/develop/protection --jq '.enforce_admins.enabled'
+```

--- a/tests/test_contracts.cpp
+++ b/tests/test_contracts.cpp
@@ -1,10 +1,23 @@
 #include "framekit/framekit.hpp"
 
-#include <cassert>
+#include <cstdlib>
 #include <cstdint>
+#include <iostream>
 #include <memory>
 
 namespace {
+
+[[noreturn]] void FailRequirement(const char* expr, int line) {
+    std::cerr << "Requirement failed at line " << line << ": " << expr << '\n';
+    std::abort();
+}
+
+#define REQUIRE(expr)            \
+    do {                         \
+        if (!(expr)) {           \
+            FailRequirement(#expr, __LINE__); \
+        }                        \
+    } while (false)
 
 class FakeProcessLauncher : public framekit::runtime::IProcessLauncher {
 public:
@@ -114,16 +127,16 @@ public:
 
 int main() {
     framekit::ApplicationSpec single_spec;
-    assert(single_spec.mode == framekit::AppMode::kSingleProcess);
-    assert(single_spec.transport_kind == framekit::IpcTransportKind::kNone);
+    REQUIRE(single_spec.mode == framekit::AppMode::kSingleProcess);
+    REQUIRE(single_spec.transport_kind == framekit::IpcTransportKind::kNone);
 
     framekit::runtime::MultiprocessRuntime runtime;
     runtime.Configure(single_spec);
 
-    assert(runtime.Start());
-    assert(runtime.IsRunning());
+    REQUIRE(runtime.Start());
+    REQUIRE(runtime.IsRunning());
     runtime.Stop();
-    assert(!runtime.IsRunning());
+    REQUIRE(!runtime.IsRunning());
 
     framekit::ApplicationSpec multiprocess_spec;
     multiprocess_spec.mode = framekit::AppMode::kMultiProcess;
@@ -144,56 +157,56 @@ int main() {
     runtime.SetLivenessPolicy(liveness);
     runtime.SetLifecycleHooks(lifecycle);
 
-    assert(runtime.Start());
-    assert(runtime.IsRunning());
-    assert(runtime.ChildProcesses().size() == 1);
+    REQUIRE(runtime.Start());
+    REQUIRE(runtime.IsRunning());
+    REQUIRE(runtime.ChildProcesses().size() == 1);
     const auto child = runtime.ChildProcesses().front();
-    assert(child.role == framekit::ProcessRole::kBackend);
+    REQUIRE(child.role == framekit::ProcessRole::kBackend);
 
     const auto handshake = runtime.ChildHandshake(child.process_id);
-    assert(handshake.has_value());
-    assert(handshake->state == framekit::runtime::ChildHandshakeState::kSpawned);
+    REQUIRE(handshake.has_value());
+    REQUIRE(handshake->state == framekit::runtime::ChildHandshakeState::kSpawned);
 
     runtime.SetChildHandshakeState(
         child.process_id,
         framekit::runtime::ChildHandshakeState::kReady,
         "ready-signal");
     const auto updated = runtime.ChildHandshake(child.process_id);
-    assert(updated.has_value());
-    assert(updated->state == framekit::runtime::ChildHandshakeState::kReady);
-    assert(updated->detail == "ready-signal");
+    REQUIRE(updated.has_value());
+    REQUIRE(updated->state == framekit::runtime::ChildHandshakeState::kReady);
+    REQUIRE(updated->detail == "ready-signal");
 
-    assert(runtime.AllChildHandshakes().size() == 1);
+    REQUIRE(runtime.AllChildHandshakes().size() == 1);
 
     runtime.Tick();
-    assert(supervisor->missed_heartbeat_ids.size() == 1);
-    assert(supervisor->missed_heartbeat_ids.front() == child.process_id);
+    REQUIRE(supervisor->missed_heartbeat_ids.size() == 1);
+    REQUIRE(supervisor->missed_heartbeat_ids.front() == child.process_id);
 
     runtime.RecordHeartbeat(child.process_id, 1);
-    assert(runtime.HeartbeatCount(child.process_id) == 1);
-    assert(liveness->heartbeat_ids.size() == 1);
-    assert(liveness->heartbeat_ids.front() == child.process_id);
+    REQUIRE(runtime.HeartbeatCount(child.process_id) == 1);
+    REQUIRE(liveness->heartbeat_ids.size() == 1);
+    REQUIRE(liveness->heartbeat_ids.front() == child.process_id);
 
     runtime.Tick();
-    assert(supervisor->missed_heartbeat_ids.size() == 1);
+    REQUIRE(supervisor->missed_heartbeat_ids.size() == 1);
 
-    assert(runtime.RestartChild(child.process_id));
-    assert(lifecycle->restart_requested_ids.size() == 1);
-    assert(lifecycle->restart_requested_ids.front() == child.process_id);
-    assert(lifecycle->restart_from_ids.size() == 1);
-    assert(lifecycle->restart_to_ids.size() == 1);
-    assert(lifecycle->restart_to_ids.front() != child.process_id);
-    assert(runtime.ChildProcesses().size() == 1);
+    REQUIRE(runtime.RestartChild(child.process_id));
+    REQUIRE(lifecycle->restart_requested_ids.size() == 1);
+    REQUIRE(lifecycle->restart_requested_ids.front() == child.process_id);
+    REQUIRE(lifecycle->restart_from_ids.size() == 1);
+    REQUIRE(lifecycle->restart_to_ids.size() == 1);
+    REQUIRE(lifecycle->restart_to_ids.front() != child.process_id);
+    REQUIRE(runtime.ChildProcesses().size() == 1);
 
     const auto restarted_child = runtime.ChildProcesses().front();
-    assert(runtime.GracefulStopChild(restarted_child.process_id));
-    assert(lifecycle->stop_requested_ids.size() == 1);
-    assert(lifecycle->stop_requested_ids.front() == restarted_child.process_id);
-    assert(lifecycle->stop_completed == 1);
-    assert(runtime.ChildProcesses().empty());
+    REQUIRE(runtime.GracefulStopChild(restarted_child.process_id));
+    REQUIRE(lifecycle->stop_requested_ids.size() == 1);
+    REQUIRE(lifecycle->stop_requested_ids.front() == restarted_child.process_id);
+    REQUIRE(lifecycle->stop_completed == 1);
+    REQUIRE(runtime.ChildProcesses().empty());
 
     runtime.Stop();
-    assert(!runtime.IsRunning());
+    REQUIRE(!runtime.IsRunning());
 
     return 0;
 }


### PR DESCRIPTION
Closes #42

Implements the operational playbook rollout for PR-only workflow governance:
- adds docs/doctrine/release-playbook.md
- links playbook from docs/doctrine/README.md and root README
- documents required checks (smoke, pr-title, issue-link, master-promotion) and failure recovery
