### PR TITLE
docs(architecture): publish lifecycle semantics

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,3 +14,4 @@
 - [FrameKit v2 Charter](charter-v2.md)
 - [External Integration Boundary Contract](integration-boundary.md)
 - [FrameKit v2 Stable Contract Inventory](v2-stable-contracts.md)
+- [Lifecycle and Shutdown Semantics](lifecycle-semantics.md)

--- a/docs/doctrine/project-board-workflow.md
+++ b/docs/doctrine/project-board-workflow.md
@@ -36,6 +36,7 @@ Policy mapping:
 Standard fields already present:
 
 - `Status`
+- `Type`
 - `Priority`
 - `Repository`
 - `Iteration`
@@ -45,6 +46,10 @@ Custom fields added for v2 planning:
 - `Depends On` (TEXT)
 - `Risk` (SINGLE_SELECT: Low, Medium, High, Critical)
 - `Architecture Area` (SINGLE_SELECT)
+
+Related required issue metadata:
+
+- `Milestone` (GitHub issue milestone; required on Phase 0 issues, not a project field)
 
 ## Automation Rules
 

--- a/docs/integration-boundary.md
+++ b/docs/integration-boundary.md
@@ -11,15 +11,17 @@ host framework and does not absorb domain-runtime semantics.
 ## Core Boundary Rules
 
 1. FrameKit core must not depend on any domain runtime implementation.
-2. Domain runtimes must not depend on FrameKit internals.
+2. Domain runtimes must not depend on FrameKit, including public contracts and internals.
 3. Integration occurs only in composition applications through explicit bridge
    modules and services.
 
 ## Dependency Separation Requirements
 
 - FrameKit contracts and runtime targets remain domain-agnostic.
-- Domain runtime repositories must not import FrameKit-only internal symbols.
-- Shared behavior is expressed through generic host contracts, not domain terms.
+- Domain runtime repositories must not have compile-time dependency on FrameKit
+   headers, contracts, or internal symbols.
+- Shared behavior contracts are defined at the composition boundary, not inside
+   FrameKit or domain runtimes.
 
 ## Composition-Only Integration Model
 
@@ -32,6 +34,9 @@ Integration pattern:
 4. Runtime-specific behavior remains outside FrameKit core and contracts.
 
 ## Allowed Integration Hooks
+
+These hooks are consumed by composition bridge modules; domain runtime
+repositories remain FrameKit-independent.
 
 - Lifecycle hooks
 - Update and render stage hooks
@@ -47,7 +52,7 @@ Integration pattern:
 ## Verification Checklist
 
 - [ ] FrameKit has no compile-time dependency on domain runtime repos.
-- [ ] Domain runtime repos have no compile-time dependency on FrameKit internals.
+- [ ] Domain runtime repos have no compile-time dependency on FrameKit.
 - [ ] Integration behavior is implemented in composition applications only.
 - [ ] Architecture docs link this boundary contract.
 

--- a/docs/lifecycle-semantics.md
+++ b/docs/lifecycle-semantics.md
@@ -1,0 +1,73 @@
+# Lifecycle and Shutdown Semantics
+
+Status: Draft
+Last Reviewed: 2026-03-29
+
+## Purpose
+
+Define the legal lifecycle states, transition rules, and shutdown guarantees for
+FrameKit v2 host runtime behavior.
+
+## Lifecycle States
+
+1. Bootstrapping
+2. Initializing
+3. Running
+4. Stopping
+5. Stopped
+6. Faulted
+
+## Legal Transition Table
+
+| Current State | Allowed Next State(s) | Notes |
+|---|---|---|
+| Bootstrapping | Initializing, Faulted | Bootstrap failure transitions directly to Faulted |
+| Initializing | Running, Stopping, Faulted | Stop request during init transitions to Stopping |
+| Running | Stopping, Faulted | Normal operation state |
+| Stopping | Stopped, Faulted | Fault during stop transitions to Faulted |
+| Stopped | Bootstrapping | Restart requires full bootstrap |
+| Faulted | Stopping, Stopped, Bootstrapping | Policy-dependent recovery path |
+
+Transitions not listed above are invalid and must be rejected.
+
+## Startup Semantics
+
+1. Kernel enters Bootstrapping exactly once per start request.
+2. Kernel enters Initializing after bootstrap prerequisites complete.
+3. Kernel enters Running only after required services/modules are ready.
+4. Any required contract failure before Running transitions to Faulted.
+
+## Shutdown Semantics
+
+### Ordered Shutdown Sequence
+
+1. Enter Stopping and stop accepting new registrations.
+2. Stop modules in reverse dependency order.
+3. Drain deferred events according to shutdown policy.
+4. Teardown platform/window host resources.
+5. Teardown services in reverse registration order.
+6. Flush diagnostics and transition to Stopped.
+
+### Shutdown Guarantees
+
+- Shutdown is deterministic and ordered.
+- Reverse-order teardown is enforced for dependency safety.
+- Completion is observable via Stopped state transition.
+- Failure in shutdown path transitions to Faulted and reports diagnostics.
+
+## Faulted-State Semantics
+
+Faulted indicates a contract-level failure that prevents normal operation.
+
+Faulted requirements:
+
+1. Must capture fault diagnostics context.
+2. Must prohibit transition to Running without new bootstrap.
+3. May allow controlled transition to Stopping for cleanup.
+4. Must expose explicit recovery path policy (restart or hard stop).
+
+## Policy Notes
+
+- Fail-fast is required for invalid transitions and required contract failures.
+- Degrade behavior is profile-policy controlled and documented separately in the
+  error policy matrix.

--- a/docs/v2-stable-contracts.md
+++ b/docs/v2-stable-contracts.md
@@ -5,7 +5,7 @@ Last Reviewed: 2026-03-29
 
 ## Purpose
 
-Define which FrameKit v2 contracts are frozen at v2.x and which areas remain
+Define which FrameKit v2 contracts are frozen for v2.x and which areas remain
 flexible for iterative implementation and adapter evolution.
 
 ## Stability Policy


### PR DESCRIPTION
Closes #53. Adds lifecycle transition table, shutdown ordering guarantees, and faulted-state semantics.