### PR TITLE
docs(architecture): seed ADR index and core ADRs

### DIFF
--- a/docs/adr/ADR-0001-service-context-model.md
+++ b/docs/adr/ADR-0001-service-context-model.md
@@ -1,0 +1,29 @@
+# ADR-0001: Service Context Model and Freeze Policy
+
+Status: Accepted
+Date: 2026-03-29
+
+## Context
+
+FrameKit requires predictable service registration and lookup semantics across
+bootstrap, running, and shutdown phases.
+
+## Decision
+
+Adopt a scoped service context with explicit phases:
+
+1. Open registration window.
+2. One-way freeze before Running.
+3. Deterministic teardown with ownership-aware lifetime handling.
+
+Typed lookups are required, and registration after freeze is a contract error.
+
+## Consequences
+
+- Service graph is stable during runtime.
+- Concurrent read-only lookup after freeze is feasible by policy.
+- Late binding flexibility is reduced in favor of deterministic behavior.
+
+## Related Docs
+
+- [Service Context Contract and Freeze Policy](../service-context-contract-freeze.md)

--- a/docs/adr/ADR-0002-module-loading-model.md
+++ b/docs/adr/ADR-0002-module-loading-model.md
@@ -1,0 +1,30 @@
+# ADR-0002: Module Loading Model (Static Baseline)
+
+Status: Accepted
+Date: 2026-03-29
+
+## Context
+
+Phase 0 requires deterministic module lifecycle behavior and dependency-safe
+startup/shutdown ordering.
+
+## Decision
+
+Use a static module registration baseline for v2 contracts:
+
+- Modules are declared before startup.
+- Dependencies form a validated DAG.
+- Startup uses deterministic topological order.
+- Shutdown uses reverse topological order.
+
+Dynamic loading remains optional future work and is out of baseline scope.
+
+## Consequences
+
+- Predictable startup/shutdown behavior.
+- Stronger validation before entering Running state.
+- Runtime extensibility is intentionally constrained in baseline v2.
+
+## Related Docs
+
+- [Module Contract and Dependency DAG Semantics](../module-contract-dag-semantics.md)

--- a/docs/adr/ADR-0003-loop-profile-policy-model.md
+++ b/docs/adr/ADR-0003-loop-profile-policy-model.md
@@ -1,0 +1,27 @@
+# ADR-0003: Loop Profiles and Policy Model
+
+Status: Accepted
+Date: 2026-03-29
+
+## Context
+
+FrameKit must support multiple host styles (interactive, headless, hybrid,
+deterministic) without fragmenting core loop contracts.
+
+## Decision
+
+Define a common baseline stage graph and a profile/policy model:
+
+- Baseline stages provide stable ordering guarantees.
+- Profiles specify required/optional stage usage.
+- Policy dimensions are orthogonal: timing, overrun, threading.
+
+## Consequences
+
+- Shared core behavior across host styles.
+- Controlled flexibility via explicit policy contracts.
+- Deterministic Host profile remains strict by design.
+
+## Related Docs
+
+- [Loop Stage Graph and Profile/Policy Specification](../loop-stage-graph-profiles.md)

--- a/docs/adr/ADR-0004-error-policy-model.md
+++ b/docs/adr/ADR-0004-error-policy-model.md
@@ -1,0 +1,29 @@
+# ADR-0004: Error Policy Matrix and Escalation Rules
+
+Status: Accepted
+Date: 2026-03-29
+
+## Context
+
+Different loop profiles require different tolerance for operational faults while
+still enforcing critical safety and contract invariants.
+
+## Decision
+
+Adopt a fault-class-by-profile policy matrix with:
+
+- explicit fail-fast conditions,
+- bounded degrade paths,
+- mandatory escalation from degrade to fail-fast when limits are exceeded.
+
+Certain invariants are always fail-fast regardless of profile.
+
+## Consequences
+
+- Error handling is explicit and testable.
+- Profile behavior remains predictable under fault.
+- Deterministic profile enforces strict escalation rules.
+
+## Related Docs
+
+- [Error Policy Matrix by Loop Profile](../error-policy-matrix.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,24 @@
+# Architecture Decision Records (ADRs)
+
+Status: Draft
+Last Reviewed: 2026-03-29
+
+## Purpose
+
+Track key architectural decisions for FrameKit v2 using concise ADRs that
+capture context, decision, and consequences.
+
+## Index
+
+| ADR | Title | Status |
+|---|---|---|
+| [ADR-0001](ADR-0001-service-context-model.md) | Service Context Model and Freeze Policy | Accepted (Phase 0) |
+| [ADR-0002](ADR-0002-module-loading-model.md) | Module Loading Model (Static Baseline) | Accepted (Phase 0) |
+| [ADR-0003](ADR-0003-loop-profile-policy-model.md) | Loop Profiles and Policy Model | Accepted (Phase 0) |
+| [ADR-0004](ADR-0004-error-policy-model.md) | Error Policy Matrix and Escalation Rules | Accepted (Phase 0) |
+
+## Usage Notes
+
+- ADRs in this index are architecture-level anchors, not implementation specs.
+- Detailed semantics remain in linked architecture contract documents.
+- Future ADRs continue numbering sequence (`ADR-0005`, `ADR-0006`, ...).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,3 +20,10 @@
 - [Service Context Contract and Freeze Policy](service-context-contract-freeze.md)
 - [Event and Input Semantics Contract](event-input-semantics.md)
 - [Error Policy Matrix by Loop Profile](error-policy-matrix.md)
+
+## Architecture Decisions
+- [ADR Index](adr/README.md)
+- [ADR-0001: Service Context Model and Freeze Policy](adr/ADR-0001-service-context-model.md)
+- [ADR-0002: Module Loading Model (Static Baseline)](adr/ADR-0002-module-loading-model.md)
+- [ADR-0003: Loop Profiles and Policy Model](adr/ADR-0003-loop-profile-policy-model.md)
+- [ADR-0004: Error Policy Matrix and Escalation Rules](adr/ADR-0004-error-policy-model.md)


### PR DESCRIPTION
## Summary\n- add ADR index under docs/adr/README.md\n- seed ADRs for service model, module loading, loop profiles, and error policy\n- integrate ADR links into architecture documentation\n\n## Tracking\n- closes #59