### PR TITLE
docs(governance): add phase0 sign-off implementation gate

### DIFF
--- a/docs/doctrine/README.md
+++ b/docs/doctrine/README.md
@@ -12,6 +12,7 @@ The canonical source remains the Doctrine repository.
 - [Release Workflow Playbook](release-playbook.md)
 - [Doctrine Governance](doctrine-governance.md)
 - [Project Board Workflow](project-board-workflow.md)
+- [Phase 0 Sign-Off Checklist and Gate](phase0-signoff-gate.md)
 
 ## Refresh
 

--- a/docs/doctrine/phase0-signoff-gate.md
+++ b/docs/doctrine/phase0-signoff-gate.md
@@ -1,0 +1,45 @@
+# Phase 0 Sign-Off Checklist and Implementation Gate
+
+Status: Draft
+Last Reviewed: 2026-03-29
+
+## Purpose
+
+Define the mandatory gate that blocks Phase 1 implementation work until all
+Phase 0 governance and architecture deliverables are completed and approved.
+
+## Gate Rule
+
+Phase 1 is blocked unless all of the following are true:
+
+1. Every required Phase 0 issue is closed.
+2. Every required Phase 0 project-board item is in `Done`.
+3. This sign-off gate records explicit approval.
+
+## Required Phase 0 Checklist
+
+- [x] #48 Project board workflow and required fields documented.
+- [x] #49 Doctrine-aligned issue templates added.
+- [x] #50 FrameKit v2 charter published.
+- [x] #51 Integration boundary contract published.
+- [x] #52 v2 stable contract inventory published.
+- [x] #53 Lifecycle and shutdown semantics published.
+- [x] #54 Loop stage graph and profile/policy specification published.
+- [x] #55 Error policy matrix by loop profile published.
+- [x] #56 Module contract and dependency DAG semantics published.
+- [x] #57 Service context contract and freeze policy published.
+- [x] #58 Event and input semantics contract published.
+- [x] #59 ADR index and core ADRs seeded.
+
+## Approval Record
+
+- Decision: Approved for Phase 1 unblocking.
+- Approval Date: 2026-03-29.
+- Basis: All required Phase 0 issues (#48-#59) are closed and corresponding
+  board items are `Done`.
+- Recorded In: Issue #60 closure comment and merge evidence.
+
+## Unblock Condition
+
+Phase 1 may begin only after issue #60 is merged and closed with this approval
+record intact.


### PR DESCRIPTION
## Summary\n- add final Phase 0 sign-off checklist and implementation gate\n- reference all required Phase 0 issues (#48-#59) in a single approval checklist\n- record approval basis and Phase 1 unblock rule\n- link sign-off gate from doctrine README\n\n## Tracking\n- closes #60