### PR TITLE
docs(architecture): apply copilot review clarifications

### DIFF
--- a/docs/adr/ADR-0001-service-context-model.md
+++ b/docs/adr/ADR-0001-service-context-model.md
@@ -2,6 +2,7 @@
 
 Status: Accepted
 Date: 2026-03-29
+Last Reviewed: 2026-03-29
 
 ## Context
 

--- a/docs/adr/ADR-0002-module-loading-model.md
+++ b/docs/adr/ADR-0002-module-loading-model.md
@@ -2,6 +2,7 @@
 
 Status: Accepted
 Date: 2026-03-29
+Last Reviewed: 2026-03-29
 
 ## Context
 

--- a/docs/adr/ADR-0003-loop-profile-policy-model.md
+++ b/docs/adr/ADR-0003-loop-profile-policy-model.md
@@ -2,6 +2,7 @@
 
 Status: Accepted
 Date: 2026-03-29
+Last Reviewed: 2026-03-29
 
 ## Context
 

--- a/docs/adr/ADR-0004-error-policy-model.md
+++ b/docs/adr/ADR-0004-error-policy-model.md
@@ -2,6 +2,7 @@
 
 Status: Accepted
 Date: 2026-03-29
+Last Reviewed: 2026-03-29
 
 ## Context
 

--- a/docs/doctrine/README.md
+++ b/docs/doctrine/README.md
@@ -12,7 +12,7 @@ The canonical source remains the Doctrine repository.
 - [Release Workflow Playbook](release-playbook.md)
 - [Doctrine Governance](doctrine-governance.md)
 - [Project Board Workflow](project-board-workflow.md)
-- [Phase 0 Sign-Off Checklist and Gate](phase0-signoff-gate.md)
+- [Phase 0 Sign-Off Checklist and Implementation Gate](phase0-signoff-gate.md)
 
 ## Refresh
 

--- a/docs/doctrine/phase0-signoff-gate.md
+++ b/docs/doctrine/phase0-signoff-gate.md
@@ -1,6 +1,6 @@
 # Phase 0 Sign-Off Checklist and Implementation Gate
 
-Status: Draft
+Status: Stable
 Last Reviewed: 2026-03-29
 
 ## Purpose
@@ -17,6 +17,9 @@ Phase 1 is blocked unless all of the following are true:
 3. This sign-off gate records explicit approval.
 
 ## Required Phase 0 Checklist
+
+This checklist is a recorded Phase 0 completion snapshot. For future phase
+gates, copy this structure and start with unchecked items.
 
 - [x] #48 Project board workflow and required fields documented.
 - [x] #49 Doctrine-aligned issue templates added.

--- a/docs/error-policy-matrix.md
+++ b/docs/error-policy-matrix.md
@@ -10,9 +10,9 @@ profiles, including mandatory fail-fast invariants and bounded degrade limits.
 
 ## Profiles
 
-- GUI Interactive
-- Headless Service
-- Hybrid Tool
+- GUI
+- Headless
+- Hybrid
 - Deterministic Host
 
 ## Fault Classes
@@ -32,7 +32,7 @@ profiles, including mandatory fail-fast invariants and bounded degrade limits.
 
 ## Policy Matrix
 
-| Fault Class | GUI Interactive | Headless Service | Hybrid Tool | Deterministic Host |
+| Fault Class | GUI | Headless | Hybrid | Deterministic Host |
 |---|---|---|---|---|
 | Bootstrap | Fail-fast | Fail-fast | Fail-fast | Fail-fast |
 | Module | Fail-fast for required module; Degrade (bounded) for optional module | Fail-fast for required module; Degrade (bounded) for optional module | Fail-fast for required module; Degrade (bounded) for optional module | Fail-fast |
@@ -49,7 +49,8 @@ The following always require fail-fast, regardless of profile:
 2. Dependency cycle or unresolved required module dependency.
 3. Registration after service-context freeze.
 4. Corrupted event queue invariants (ordering/ownership corruption).
-5. Determinism contract breach in Deterministic Host profile.
+5. Determinism contract breach when determinism is required by the active
+  profile.
 6. Any fault that compromises safe shutdown sequencing.
 
 ## Degrade Limits

--- a/docs/event-input-semantics.md
+++ b/docs/event-input-semantics.md
@@ -20,7 +20,8 @@ FrameKit event dispatch has two paths:
 
 - Event is delivered in the caller's execution flow.
 - Handlers execute in deterministic registration order.
-- Immediate handler failures follow configured error policy.
+- Immediate handler failures follow the
+  [Error Policy Matrix by Loop Profile](error-policy-matrix.md).
 
 ### Deferred Dispatch
 
@@ -29,6 +30,16 @@ FrameKit event dispatch has two paths:
 - Deferred events preserve FIFO ordering within the same priority class.
 - Deferred handlers observe world state after update-stage completion for the
   current frame.
+
+#### Deferred Priority Classes
+
+- A priority class is a label on a deferred event that determines relative
+  drain order.
+- Implementations must support at least one priority class: `normal`.
+- Additional classes such as `high` or `low` are optional and policy-defined.
+- Cross-priority ordering is deterministic: higher priority classes drain
+  before lower classes.
+- Within each class, events drain in FIFO enqueue order.
 
 ## Propagation and Consume Rules
 
@@ -47,8 +58,9 @@ Event propagation contract:
 Queue behavior requirements:
 
 - Queue supports bounded capacity policy per host profile.
-- Capacity overflow handling is policy-driven (drop_noncritical, fail_fast,
-  or backpressure signaling).
+- Capacity overflow handling is policy-driven
+  (`queue_drop_noncritical`, `queue_fail_fast`, or
+  `queue_backpressure_signaling`).
 - Queue drain is repeatable and observable for diagnostics.
 - Shutdown drain policy is explicit (drain all, drain bounded, or discard
   with diagnostics).

--- a/docs/lifecycle-semantics.md
+++ b/docs/lifecycle-semantics.md
@@ -69,5 +69,5 @@ Faulted requirements:
 ## Policy Notes
 
 - Fail-fast is required for invalid transitions and required contract failures.
-- Degrade behavior is profile-policy controlled and documented separately in the
-  error policy matrix.
+- Degrade behavior is profile-policy controlled and documented in the
+  [Error Policy Matrix by Loop Profile](error-policy-matrix.md).

--- a/docs/loop-stage-graph-profiles.md
+++ b/docs/loop-stage-graph-profiles.md
@@ -41,14 +41,16 @@ Default stage order for the baseline host loop:
 
 Profiles constrain stage usage and default policy behavior.
 
-### GUI Interactive
+Canonical profile names are: GUI, Headless, Hybrid, and Deterministic Host.
+
+### GUI (Interactive)
 
 - Target: desktop UI and graphics-forward hosts.
 - Required stages: all baseline stages.
-- Defaults: variable timing, soft overrun handling, single-threaded or split
+- Defaults: variable timing, `slip` overrun mode, single-threaded or split
   update/render.
 
-### Headless Service
+### Headless
 
 - Target: service/automation hosts without window rendering.
 - Required stages: BeginFrame, ProcessPlatformEvents, NormalizeInput,
@@ -58,7 +60,7 @@ Profiles constrain stage usage and default policy behavior.
 - Defaults: externally-clocked or fixed timing, bounded catch-up overrun mode,
   single-threaded.
 
-### Hybrid Tool
+### Hybrid
 
 - Target: tooling applications mixing interactive views and background work.
 - Required stages: all baseline stages.
@@ -88,7 +90,8 @@ Loop policy is expressed using three orthogonal dimensions.
 
 - `slip`: process one step and allow frame drift.
 - `catch_up_bounded`: run bounded extra update steps to reduce drift.
-- `drop_noncritical`: skip noncritical work stages as policy allows.
+- `drop_noncritical`: skip only stages that are explicitly marked optional or
+  degradable by the active profile and policy.
 - `fail_fast`: treat sustained overrun as a contract failure.
 
 ### Threading Mode
@@ -102,12 +105,15 @@ Loop policy is expressed using three orthogonal dimensions.
 - `fixed_delta` + `catch_up_bounded` requires an explicit max catch-up step
   budget.
 - `fail_fast` cannot silently degrade to `slip`.
+- `drop_noncritical` must preserve non-optional ordering guarantees, including
+  `PreUpdate`/`Update`/`PostUpdate` and, when rendering is enabled,
+  `PreRender`/`Render`/`PostRender` wrapper integrity.
 - `host_managed` must preserve baseline stage ordering guarantees.
 - Any profile-specific optional stage disablement must be declared in policy.
 
 ## Acceptance Mapping
 
 - Baseline stage graph documented: see Baseline Stage Graph.
-- Profiles documented: GUI Interactive, Headless Service, Hybrid Tool,
+- Profiles documented: GUI, Headless, Hybrid,
   Deterministic Host.
 - Policy contract documented: Timing Mode, Overrun Mode, Threading Mode.

--- a/docs/module-contract-dag-semantics.md
+++ b/docs/module-contract-dag-semantics.md
@@ -15,7 +15,8 @@ Each module exposes the following contract metadata:
 
 - Stable module identifier.
 - Declared dependency list (required and optional).
-- Lifecycle entry points for initialize, start, stop, and teardown.
+- Lifecycle entry points for `initialize`, `start`, `stop`, and `teardown`
+  callbacks.
 - Capability metadata for diagnostics and startup reporting.
 
 Dynamic module loading/discovery is out of scope for this contract.
@@ -35,11 +36,16 @@ Module lifecycle states:
 ### Lifecycle Rules
 
 - Declared modules transition to Resolved only after dependency resolution.
-- Resolved modules transition to Initializing in deterministic startup order.
-- Initializing transitions to Active only after successful startup callback.
-- Startup failure transitions module to Faulted and aborts further startup.
-- Active modules transition to Stopping when host shutdown begins.
-- Stopping modules transition to Stopped after teardown callback completion.
+- Resolved modules transition to Initializing in deterministic startup order and
+  invocation of the module `initialize` callback.
+- Initializing transitions to Active only after successful completion of the
+  module `start` callback.
+- Startup failure in either `initialize` or `start` transitions module to
+  Faulted and aborts further startup.
+- Active modules transition to Stopping when host shutdown begins and the
+  module `stop` callback is invoked.
+- Stopping modules transition to Stopped only after completion of `stop` and,
+  when implemented, `teardown` callbacks.
 - Faulted modules must not transition to Active without full host restart.
 
 ## Dependency DAG Semantics
@@ -63,22 +69,28 @@ Validation is fail-fast and deterministic.
 
 ### Deterministic Topological Order
 
-- Startup order is derived from topological sort of the validated DAG.
-- If multiple valid orders exist, tie-break by stable module identifier.
-- Order must be reproducible for identical module sets and declarations.
+- Let base order `T` be a deterministic topological order of the validated DAG
+  such that for each edge `consumer -> dependency`, the consumer appears before
+  the dependency in `T`.
+- If multiple valid base orders exist, tie-break by stable module identifier.
+- Startup order is `reverse(T)`, producing dependency-first startup.
+- For identical module sets and declarations, `T` and `reverse(T)` must be
+  reproducible.
 
 ## Startup Ordering Guarantees
 
 - A module starts only after all required dependencies are Active.
 - Optional dependency availability is observable but not required to start.
-- Startup proceeds in deterministic topological order.
+- Startup proceeds in deterministic dependency-first order (`reverse(T)`).
 - On startup fault, host transitions to fault handling semantics.
 
 ## Shutdown Semantics
 
 ### Reverse-Order Shutdown Rules
 
-- Shutdown order is reverse topological order of started modules.
+- Shutdown order follows base order `T` restricted to started modules (consumer
+  before dependency), which is equivalent to reversing the actual startup
+  sequence.
 - Dependents are stopped before their dependencies.
 - Each module receives stop/teardown callbacks at most once.
 - Shutdown continues best-effort after non-fatal module stop failures, while

--- a/docs/service-context-contract-freeze.md
+++ b/docs/service-context-contract-freeze.md
@@ -20,6 +20,23 @@ Service context phases:
 2. Frozen (registration prohibited)
 3. Teardown (lookup and usage wind-down)
 
+### Lifecycle Mapping
+
+- Open maps to Bootstrapping and Initializing.
+- Frozen maps to Running and early Stopping.
+- Teardown maps to service teardown during Stopping through Stopped.
+- Registration is prohibited after the first freeze transition for the
+  remainder of the host start cycle.
+
+### Service Identity
+
+Service registration and lookup identity is the tuple:
+
+- Contract type (required).
+- Service key (optional string token; empty key is the default binding).
+
+Uniqueness is enforced on the full `(contract type, service key)` tuple.
+
 ## Registration Window
 
 Registration window rules:
@@ -38,6 +55,19 @@ Freeze point rules:
 - Freeze occurs before entering Running state.
 - After freeze, registry membership is immutable.
 - Freeze completion is observable for diagnostics/testing.
+
+## Teardown Semantics
+
+Teardown transition and operation rules:
+
+- Frozen transitions to Teardown when host shutdown begins service teardown.
+- During Teardown, registration remains prohibited and registry membership
+  remains immutable.
+- Required runtime lookups are rejected once Teardown begins; shutdown code
+  must use dependencies resolved before Teardown.
+- Optional diagnostic lookups may be permitted by policy only for services not
+  yet torn down.
+- Teardown completes when service teardown sequence is finished.
 
 ## Typed Lookup Semantics
 
@@ -64,19 +94,30 @@ Ownership model rules:
 Thread-safety expectations:
 
 - Registration and freeze transitions are single-writer operations.
-- Read-only lookup after freeze is safe for concurrent access when host policy
-  enables multithreaded execution.
+- `single_threaded`: registration, freeze, and lookup occur on one thread in
+  program order.
+- `split_update_render`: freeze completion must happen-before any concurrent
+  lookup on render threads.
+- `host_managed`: host must guarantee freeze completion happens-before any
+  concurrent lookup and no post-freeze mutation while lookups are active.
+- Read-only lookup against a frozen registry is safe for concurrent access
+  under the above ordering constraints.
 - Any mutable service state remains the responsibility of service
   implementation; registry guarantees do not imply object-level thread safety.
-- Host-managed threading mode must preserve freeze-before-concurrent-lookup
-  ordering.
+
+## Diagnostics Severity Taxonomy
+
+- `diagnostic-warning`: non-fatal policy deviation; system remains operational.
+- `diagnostic-error`: contract violation requiring explicit operator/developer
+  visibility; escalation behavior is policy-driven.
+- `diagnostic-fatal`: non-recoverable contract violation requiring fail-fast.
 
 ## Failure Semantics
 
 - Registration after freeze is a contract error.
 - Required service missing at startup transitions host to fault handling.
-- Ownership/lifetime violations are diagnostics-level errors and may escalate
-  to fail-fast by policy.
+- Ownership/lifetime violations are `diagnostic-error` by default and may
+  escalate to fail-fast by policy.
 
 ## Acceptance Mapping
 


### PR DESCRIPTION
Closes #72. Applies actionable Copilot review follow-ups from recent merged PRs (#61-#71).