### PR TITLE
docs(architecture): resolve PR73 Copilot follow-ups

### DIFF
--- a/docs/module-contract-dag-semantics.md
+++ b/docs/module-contract-dag-semantics.md
@@ -16,7 +16,7 @@ Each module exposes the following contract metadata:
 - Stable module identifier.
 - Declared dependency list (required and optional).
 - Lifecycle entry points for `initialize`, `start`, `stop`, and `teardown`
-  callbacks.
+  callbacks (`teardown` may be a no-op, but callback presence is required).
 - Capability metadata for diagnostics and startup reporting.
 
 Dynamic module loading/discovery is out of scope for this contract.
@@ -44,8 +44,8 @@ Module lifecycle states:
   Faulted and aborts further startup.
 - Active modules transition to Stopping when host shutdown begins and the
   module `stop` callback is invoked.
-- Stopping modules transition to Stopped only after completion of `stop` and,
-  when implemented, `teardown` callbacks.
+- Stopping modules transition to Stopped only after completion of `stop`,
+  followed by completion of the module `teardown` callback.
 - Faulted modules must not transition to Active without full host restart.
 
 ## Dependency DAG Semantics

--- a/docs/service-context-contract-freeze.md
+++ b/docs/service-context-contract-freeze.md
@@ -24,7 +24,8 @@ Service context phases:
 
 - Open maps to Bootstrapping and Initializing.
 - Frozen maps to Running and early Stopping.
-- Teardown maps to service teardown during Stopping through Stopped.
+- Teardown maps to service teardown during Stopping and completes before
+  entering Stopped.
 - Registration is prohibited after the first freeze transition for the
   remainder of the host start cycle.
 


### PR DESCRIPTION
Closes #75. Clarifies service-context teardown state mapping and makes module teardown callback requirement explicit per Copilot review on PR #73.