### PR TITLE
feat(core): add loop stage graph runner and profile execution (#79)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(framekit_core STATIC
     src/multiprocess_runtime.cpp
     src/lifecycle_state_machine.cpp
     src/loop_policy.cpp
+    src/loop_stage_graph.cpp
     src/module_graph.cpp
     src/event_bus.cpp
     src/bootstrap_services.cpp

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -8,6 +8,7 @@ Current baseline includes:
 - multiprocess runtime skeleton
 - lifecycle state machine and kernel runtime start/stop orchestration
 - loop profile and execution-policy validation contracts
+- loop stage graph runner with deterministic baseline-stage execution order
 - service context freeze/lookup semantics and teardown ordering
 - module dependency DAG validation with deterministic startup/shutdown ordering
 - event bus immediate/deferred dispatch baseline with consume and priority semantics

--- a/include/framekit/framekit.hpp
+++ b/include/framekit/framekit.hpp
@@ -10,6 +10,7 @@
 #include "framekit/runtime/lifecycle_state.hpp"
 #include "framekit/runtime/lifecycle_state_machine.hpp"
 #include "framekit/runtime/loop_policy.hpp"
+#include "framekit/runtime/loop_stage_graph.hpp"
 #include "framekit/runtime/module_graph.hpp"
 #include "framekit/runtime/event_bus.hpp"
 #include "framekit/runtime/service_context.hpp"

--- a/include/framekit/runtime/loop_stage_graph.hpp
+++ b/include/framekit/runtime/loop_stage_graph.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "framekit/runtime/loop_policy.hpp"
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace framekit::runtime {
+
+enum class LoopStage : std::uint8_t {
+    kBeginFrame = 0,
+    kProcessPlatformEvents = 1,
+    kNormalizeInput = 2,
+    kDispatchImmediateEvents = 3,
+    kPreUpdate = 4,
+    kUpdate = 5,
+    kPostUpdate = 6,
+    kDispatchDeferredEvents = 7,
+    kPreRender = 8,
+    kRender = 9,
+    kPostRender = 10,
+    kEndFrame = 11,
+};
+
+const std::vector<LoopStage>& BaselineLoopStageOrder();
+const char* LoopStageName(LoopStage stage);
+bool ParseLoopStageName(const std::string& name, LoopStage* out_stage);
+
+class LoopStageGraphRunner {
+public:
+    using StageHandler = std::function<void()>;
+
+    bool Configure(const LoopPolicy& policy);
+    void SetStageHandler(LoopStage stage, StageHandler handler);
+    void ClearStageHandlers();
+
+    bool ExecuteFrame();
+
+    bool IsConfigured() const;
+    const LoopPolicy& Policy() const;
+    const std::vector<LoopStage>& ActiveStages() const;
+    const std::vector<LoopStage>& LastExecutedStages() const;
+    const std::string& LastError() const;
+
+private:
+    struct LoopStageHash {
+        std::size_t operator()(LoopStage stage) const {
+            return static_cast<std::size_t>(stage);
+        }
+    };
+
+    LoopPolicy policy_;
+    std::unordered_map<LoopStage, StageHandler, LoopStageHash> handlers_;
+    std::vector<LoopStage> active_stages_;
+    std::vector<LoopStage> last_executed_stages_;
+    std::string last_error_;
+    bool configured_ = false;
+};
+
+} // namespace framekit::runtime

--- a/src/loop_stage_graph.cpp
+++ b/src/loop_stage_graph.cpp
@@ -1,0 +1,168 @@
+#include "framekit/runtime/loop_stage_graph.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <set>
+
+namespace framekit::runtime {
+
+namespace {
+
+const std::array<std::pair<LoopStage, const char*>, 12> kStageNameTable = {{
+    {LoopStage::kBeginFrame, "BeginFrame"},
+    {LoopStage::kProcessPlatformEvents, "ProcessPlatformEvents"},
+    {LoopStage::kNormalizeInput, "NormalizeInput"},
+    {LoopStage::kDispatchImmediateEvents, "DispatchImmediateEvents"},
+    {LoopStage::kPreUpdate, "PreUpdate"},
+    {LoopStage::kUpdate, "Update"},
+    {LoopStage::kPostUpdate, "PostUpdate"},
+    {LoopStage::kDispatchDeferredEvents, "DispatchDeferredEvents"},
+    {LoopStage::kPreRender, "PreRender"},
+    {LoopStage::kRender, "Render"},
+    {LoopStage::kPostRender, "PostRender"},
+    {LoopStage::kEndFrame, "EndFrame"},
+}};
+
+} // namespace
+
+const std::vector<LoopStage>& BaselineLoopStageOrder() {
+    static const std::vector<LoopStage> kBaselineOrder = {
+        LoopStage::kBeginFrame,
+        LoopStage::kProcessPlatformEvents,
+        LoopStage::kNormalizeInput,
+        LoopStage::kDispatchImmediateEvents,
+        LoopStage::kPreUpdate,
+        LoopStage::kUpdate,
+        LoopStage::kPostUpdate,
+        LoopStage::kDispatchDeferredEvents,
+        LoopStage::kPreRender,
+        LoopStage::kRender,
+        LoopStage::kPostRender,
+        LoopStage::kEndFrame,
+    };
+
+    return kBaselineOrder;
+}
+
+const char* LoopStageName(LoopStage stage) {
+    const auto found = std::find_if(
+        kStageNameTable.begin(),
+        kStageNameTable.end(),
+        [stage](const auto& item) { return item.first == stage; });
+
+    if (found == kStageNameTable.end()) {
+        return "UnknownStage";
+    }
+
+    return found->second;
+}
+
+bool ParseLoopStageName(const std::string& name, LoopStage* out_stage) {
+    if (!out_stage) {
+        return false;
+    }
+
+    const auto found = std::find_if(
+        kStageNameTable.begin(),
+        kStageNameTable.end(),
+        [&name](const auto& item) { return name == item.second; });
+
+    if (found == kStageNameTable.end()) {
+        return false;
+    }
+
+    *out_stage = found->first;
+    return true;
+}
+
+bool LoopStageGraphRunner::Configure(const LoopPolicy& policy) {
+    const auto validation = ValidateLoopPolicy(policy);
+    if (!validation.valid) {
+        last_error_ = validation.reason;
+        configured_ = false;
+        return false;
+    }
+
+    std::set<LoopStage> disabled;
+    for (const auto& stage_name : policy.disabled_optional_stages) {
+        LoopStage stage = LoopStage::kBeginFrame;
+        if (!ParseLoopStageName(stage_name, &stage)) {
+            last_error_ = "unknown loop stage in policy disable list: " + stage_name;
+            configured_ = false;
+            return false;
+        }
+
+        disabled.insert(stage);
+    }
+
+    active_stages_.clear();
+    active_stages_.reserve(BaselineLoopStageOrder().size());
+    for (const auto stage : BaselineLoopStageOrder()) {
+        if (disabled.find(stage) != disabled.end()) {
+            continue;
+        }
+        active_stages_.push_back(stage);
+    }
+
+    policy_ = policy;
+    configured_ = true;
+    last_error_.clear();
+    last_executed_stages_.clear();
+    return true;
+}
+
+void LoopStageGraphRunner::SetStageHandler(LoopStage stage, StageHandler handler) {
+    if (!handler) {
+        handlers_.erase(stage);
+        return;
+    }
+
+    handlers_[stage] = std::move(handler);
+}
+
+void LoopStageGraphRunner::ClearStageHandlers() {
+    handlers_.clear();
+}
+
+bool LoopStageGraphRunner::ExecuteFrame() {
+    if (!configured_) {
+        last_error_ = "loop stage graph runner is not configured";
+        return false;
+    }
+
+    last_executed_stages_.clear();
+    last_executed_stages_.reserve(active_stages_.size());
+
+    for (const auto stage : active_stages_) {
+        last_executed_stages_.push_back(stage);
+
+        const auto handler_it = handlers_.find(stage);
+        if (handler_it != handlers_.end() && handler_it->second) {
+            handler_it->second();
+        }
+    }
+
+    return true;
+}
+
+bool LoopStageGraphRunner::IsConfigured() const {
+    return configured_;
+}
+
+const LoopPolicy& LoopStageGraphRunner::Policy() const {
+    return policy_;
+}
+
+const std::vector<LoopStage>& LoopStageGraphRunner::ActiveStages() const {
+    return active_stages_;
+}
+
+const std::vector<LoopStage>& LoopStageGraphRunner::LastExecutedStages() const {
+    return last_executed_stages_;
+}
+
+const std::string& LoopStageGraphRunner::LastError() const {
+    return last_error_;
+}
+
+} // namespace framekit::runtime

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,3 +11,10 @@ add_executable(framekit_runtime_contract_primitives_test
 
 target_link_libraries(framekit_runtime_contract_primitives_test PRIVATE FrameKit::Core)
 add_test(NAME framekit_runtime_contract_primitives_test COMMAND framekit_runtime_contract_primitives_test)
+
+add_executable(framekit_loop_stage_graph_test
+    test_loop_stage_graph.cpp
+)
+
+target_link_libraries(framekit_loop_stage_graph_test PRIVATE FrameKit::Core)
+add_test(NAME framekit_loop_stage_graph_test COMMAND framekit_loop_stage_graph_test)

--- a/tests/test_loop_stage_graph.cpp
+++ b/tests/test_loop_stage_graph.cpp
@@ -1,0 +1,108 @@
+#include "framekit/framekit.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+[[noreturn]] void FailRequirement(const char* expr, int line) {
+    std::cerr << "Requirement failed at line " << line << ": " << expr << '\n';
+    std::abort();
+}
+
+#define REQUIRE(expr)            \
+    do {                         \
+        if (!(expr)) {           \
+            FailRequirement(#expr, __LINE__); \
+        }                        \
+    } while (false)
+
+std::vector<std::string> StageNames(const std::vector<framekit::runtime::LoopStage>& stages) {
+    std::vector<std::string> names;
+    names.reserve(stages.size());
+    for (const auto stage : stages) {
+        names.push_back(framekit::runtime::LoopStageName(stage));
+    }
+    return names;
+}
+
+void TestBaselineGuiExecutionOrder() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kGui;
+    policy.rendering_enabled = true;
+
+    framekit::runtime::LoopStageGraphRunner runner;
+    REQUIRE(runner.Configure(policy));
+
+    std::vector<std::string> observed;
+    for (const auto stage : framekit::runtime::BaselineLoopStageOrder()) {
+        runner.SetStageHandler(stage, [&observed, stage]() {
+            observed.push_back(framekit::runtime::LoopStageName(stage));
+        });
+    }
+
+    REQUIRE(runner.ExecuteFrame());
+    const auto expected = StageNames(framekit::runtime::BaselineLoopStageOrder());
+    REQUIRE(observed == expected);
+    REQUIRE(StageNames(runner.LastExecutedStages()) == expected);
+}
+
+void TestHeadlessRenderStagesOmitted() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kHeadless;
+    policy.rendering_enabled = false;
+    policy.disabled_optional_stages = {"PreRender", "Render", "PostRender"};
+
+    framekit::runtime::LoopStageGraphRunner runner;
+    REQUIRE(runner.Configure(policy));
+
+    REQUIRE(runner.ActiveStages().size() == 9);
+    const auto active_names = StageNames(runner.ActiveStages());
+
+    REQUIRE(std::find(active_names.begin(), active_names.end(), "PreRender") == active_names.end());
+    REQUIRE(std::find(active_names.begin(), active_names.end(), "Render") == active_names.end());
+    REQUIRE(std::find(active_names.begin(), active_names.end(), "PostRender") == active_names.end());
+
+    REQUIRE(runner.ExecuteFrame());
+    REQUIRE(StageNames(runner.LastExecutedStages()) == active_names);
+}
+
+void TestInvalidPolicyRejected() {
+    framekit::runtime::LoopPolicy invalid;
+    invalid.profile = framekit::runtime::LoopProfile::kHeadless;
+    invalid.rendering_enabled = false;
+
+    framekit::runtime::LoopStageGraphRunner runner;
+    REQUIRE(!runner.Configure(invalid));
+    REQUIRE(!runner.LastError().empty());
+    REQUIRE(!runner.IsConfigured());
+}
+
+void TestUnknownDisabledStageRejected() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kHeadless;
+    policy.rendering_enabled = false;
+    policy.disabled_optional_stages = {
+        "PreRender",
+        "Render",
+        "PostRender",
+        "NotAStage",
+    };
+
+    framekit::runtime::LoopStageGraphRunner runner;
+    REQUIRE(!runner.Configure(policy));
+    REQUIRE(!runner.LastError().empty());
+}
+
+} // namespace
+
+int main() {
+    TestBaselineGuiExecutionOrder();
+    TestHeadlessRenderStagesOmitted();
+    TestInvalidPolicyRejected();
+    TestUnknownDisabledStageRejected();
+    return 0;
+}


### PR DESCRIPTION
Summary: adds deterministic baseline loop-stage runner with profile-aware optional-stage execution and contract tests.\n\nValidation:\n- cmake -S /Users/georgegil/Projects/Private/FrameKit/framekit -B /Users/georgegil/Projects/Private/FrameKit/framekit/build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON\n- cmake --build /Users/georgegil/Projects/Private/FrameKit/framekit/build -j4\n- ctest --test-dir /Users/georgegil/Projects/Private/FrameKit/framekit/build --output-on-failure\n\nCloses #79