### PR TITLE
feat(core): integrate platform and window host runtime (#81)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(framekit_core STATIC
     src/lifecycle_state_machine.cpp
     src/loop_policy.cpp
     src/loop_stage_graph.cpp
+    src/platform_host_runtime.cpp
     src/module_graph.cpp
     src/event_bus.cpp
     src/bootstrap_services.cpp

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -9,6 +9,7 @@ Current baseline includes:
 - lifecycle state machine and kernel runtime start/stop orchestration
 - loop profile and execution-policy validation contracts
 - loop stage graph runner with deterministic baseline-stage execution order
+- platform/window host baseline runtime integrated with stage-driven event pump and render hooks
 - service context freeze/lookup semantics and teardown ordering
 - module dependency DAG validation with deterministic startup/shutdown ordering
 - event bus immediate/deferred dispatch baseline with consume and priority semantics

--- a/include/framekit/framekit.hpp
+++ b/include/framekit/framekit.hpp
@@ -11,6 +11,7 @@
 #include "framekit/runtime/lifecycle_state_machine.hpp"
 #include "framekit/runtime/loop_policy.hpp"
 #include "framekit/runtime/loop_stage_graph.hpp"
+#include "framekit/runtime/platform_host_runtime.hpp"
 #include "framekit/runtime/module_graph.hpp"
 #include "framekit/runtime/event_bus.hpp"
 #include "framekit/runtime/service_context.hpp"

--- a/include/framekit/runtime/platform_host_runtime.hpp
+++ b/include/framekit/runtime/platform_host_runtime.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "framekit/runtime/loop_policy.hpp"
+#include "framekit/runtime/loop_stage_graph.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace framekit::runtime {
+
+struct WindowSpec {
+    std::string title = "FrameKit";
+    std::uint32_t width = 1280;
+    std::uint32_t height = 720;
+    bool visible = true;
+};
+
+class IPlatformHost {
+public:
+    virtual ~IPlatformHost() = default;
+
+    virtual bool Initialize() = 0;
+    virtual bool PumpEvents() = 0;
+    virtual bool Teardown() = 0;
+};
+
+class IWindowHost {
+public:
+    virtual ~IWindowHost() = default;
+
+    virtual bool CreatePrimaryWindow(const WindowSpec& spec) = 0;
+    virtual bool PreRender() = 0;
+    virtual bool Render() = 0;
+    virtual bool PostRender() = 0;
+    virtual bool TeardownWindows() = 0;
+};
+
+class PlatformHostRuntime {
+public:
+    void SetPlatformHost(std::shared_ptr<IPlatformHost> host);
+    void SetWindowHost(std::shared_ptr<IWindowHost> host);
+
+    bool Configure(const LoopPolicy& policy, WindowSpec primary_window = {});
+    bool Start();
+    bool Tick();
+    bool Stop();
+
+    bool IsConfigured() const;
+    bool IsRunning() const;
+
+    const std::vector<LoopStage>& ActiveStages() const;
+    const std::vector<LoopStage>& LastFrameStages() const;
+    const std::string& LastError() const;
+
+private:
+    bool HasActiveRenderStages() const;
+    void SetErrorForStage(LoopStage stage, const char* message);
+
+    LoopStageGraphRunner loop_runner_;
+    LoopPolicy policy_;
+    WindowSpec primary_window_;
+    std::shared_ptr<IPlatformHost> platform_host_;
+    std::shared_ptr<IWindowHost> window_host_;
+    bool configured_ = false;
+    bool running_ = false;
+    bool window_created_ = false;
+    bool frame_failed_ = false;
+    std::string last_error_;
+};
+
+} // namespace framekit::runtime

--- a/src/platform_host_runtime.cpp
+++ b/src/platform_host_runtime.cpp
@@ -1,0 +1,206 @@
+#include "framekit/runtime/platform_host_runtime.hpp"
+
+#include <algorithm>
+
+namespace framekit::runtime {
+
+void PlatformHostRuntime::SetPlatformHost(std::shared_ptr<IPlatformHost> host) {
+    platform_host_ = std::move(host);
+}
+
+void PlatformHostRuntime::SetWindowHost(std::shared_ptr<IWindowHost> host) {
+    window_host_ = std::move(host);
+}
+
+bool PlatformHostRuntime::Configure(const LoopPolicy& policy, WindowSpec primary_window) {
+    if (running_) {
+        last_error_ = "cannot configure platform runtime while running";
+        configured_ = false;
+        return false;
+    }
+
+    if (!loop_runner_.Configure(policy)) {
+        last_error_ = loop_runner_.LastError();
+        configured_ = false;
+        return false;
+    }
+
+    policy_ = policy;
+    primary_window_ = std::move(primary_window);
+
+    loop_runner_.ClearStageHandlers();
+    loop_runner_.SetStageHandler(LoopStage::kProcessPlatformEvents, [this]() {
+        if (!platform_host_) {
+            SetErrorForStage(LoopStage::kProcessPlatformEvents, "platform host is not set");
+            return;
+        }
+
+        if (!platform_host_->PumpEvents()) {
+            SetErrorForStage(LoopStage::kProcessPlatformEvents, "platform host failed to pump events");
+        }
+    });
+
+    loop_runner_.SetStageHandler(LoopStage::kPreRender, [this]() {
+        if (!window_host_) {
+            SetErrorForStage(LoopStage::kPreRender, "window host is not set");
+            return;
+        }
+
+        if (!window_host_->PreRender()) {
+            SetErrorForStage(LoopStage::kPreRender, "window host pre-render failed");
+        }
+    });
+
+    loop_runner_.SetStageHandler(LoopStage::kRender, [this]() {
+        if (!window_host_) {
+            SetErrorForStage(LoopStage::kRender, "window host is not set");
+            return;
+        }
+
+        if (!window_host_->Render()) {
+            SetErrorForStage(LoopStage::kRender, "window host render failed");
+        }
+    });
+
+    loop_runner_.SetStageHandler(LoopStage::kPostRender, [this]() {
+        if (!window_host_) {
+            SetErrorForStage(LoopStage::kPostRender, "window host is not set");
+            return;
+        }
+
+        if (!window_host_->PostRender()) {
+            SetErrorForStage(LoopStage::kPostRender, "window host post-render failed");
+        }
+    });
+
+    frame_failed_ = false;
+    last_error_.clear();
+    configured_ = true;
+    return true;
+}
+
+bool PlatformHostRuntime::Start() {
+    if (!configured_) {
+        last_error_ = "platform runtime is not configured";
+        return false;
+    }
+
+    if (running_) {
+        last_error_ = "platform runtime is already running";
+        return false;
+    }
+
+    if (!platform_host_) {
+        last_error_ = "platform host is required";
+        return false;
+    }
+
+    if (!platform_host_->Initialize()) {
+        last_error_ = "platform host initialization failed";
+        return false;
+    }
+
+    if (HasActiveRenderStages()) {
+        if (!window_host_) {
+            last_error_ = "window host is required when render stages are active";
+            return false;
+        }
+
+        if (!window_host_->CreatePrimaryWindow(primary_window_)) {
+            last_error_ = "window host failed to create primary window";
+            return false;
+        }
+
+        window_created_ = true;
+    }
+
+    running_ = true;
+    last_error_.clear();
+    return true;
+}
+
+bool PlatformHostRuntime::Tick() {
+    if (!running_) {
+        last_error_ = "platform runtime is not running";
+        return false;
+    }
+
+    frame_failed_ = false;
+    last_error_.clear();
+
+    if (!loop_runner_.ExecuteFrame()) {
+        last_error_ = loop_runner_.LastError();
+        return false;
+    }
+
+    return !frame_failed_;
+}
+
+bool PlatformHostRuntime::Stop() {
+    if (!running_) {
+        return true;
+    }
+
+    bool ok = true;
+    if (window_created_ && window_host_) {
+        if (!window_host_->TeardownWindows()) {
+            ok = false;
+            if (last_error_.empty()) {
+                last_error_ = "window host teardown failed";
+            }
+        }
+    }
+
+    if (!platform_host_->Teardown()) {
+        ok = false;
+        if (last_error_.empty()) {
+            last_error_ = "platform host teardown failed";
+        }
+    }
+
+    running_ = false;
+    window_created_ = false;
+    frame_failed_ = false;
+    return ok;
+}
+
+bool PlatformHostRuntime::IsConfigured() const {
+    return configured_;
+}
+
+bool PlatformHostRuntime::IsRunning() const {
+    return running_;
+}
+
+const std::vector<LoopStage>& PlatformHostRuntime::ActiveStages() const {
+    return loop_runner_.ActiveStages();
+}
+
+const std::vector<LoopStage>& PlatformHostRuntime::LastFrameStages() const {
+    return loop_runner_.LastExecutedStages();
+}
+
+const std::string& PlatformHostRuntime::LastError() const {
+    return last_error_;
+}
+
+bool PlatformHostRuntime::HasActiveRenderStages() const {
+    const auto& active_stages = loop_runner_.ActiveStages();
+    return std::find(active_stages.begin(), active_stages.end(), LoopStage::kPreRender) != active_stages.end() ||
+        std::find(active_stages.begin(), active_stages.end(), LoopStage::kRender) != active_stages.end() ||
+        std::find(active_stages.begin(), active_stages.end(), LoopStage::kPostRender) != active_stages.end();
+}
+
+void PlatformHostRuntime::SetErrorForStage(LoopStage stage, const char* message) {
+    frame_failed_ = true;
+    if (!last_error_.empty()) {
+        return;
+    }
+
+    last_error_ = "loop stage ";
+    last_error_ += LoopStageName(stage);
+    last_error_ += " failed: ";
+    last_error_ += message;
+}
+
+} // namespace framekit::runtime

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,3 +18,10 @@ add_executable(framekit_loop_stage_graph_test
 
 target_link_libraries(framekit_loop_stage_graph_test PRIVATE FrameKit::Core)
 add_test(NAME framekit_loop_stage_graph_test COMMAND framekit_loop_stage_graph_test)
+
+add_executable(framekit_platform_host_runtime_test
+    test_platform_host_runtime.cpp
+)
+
+target_link_libraries(framekit_platform_host_runtime_test PRIVATE FrameKit::Core)
+add_test(NAME framekit_platform_host_runtime_test COMMAND framekit_platform_host_runtime_test)

--- a/tests/test_platform_host_runtime.cpp
+++ b/tests/test_platform_host_runtime.cpp
@@ -1,0 +1,224 @@
+#include "framekit/framekit.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+[[noreturn]] void FailRequirement(const char* expr, int line) {
+    std::cerr << "Requirement failed at line " << line << ": " << expr << '\n';
+    std::abort();
+}
+
+#define REQUIRE(expr)            \
+    do {                         \
+        if (!(expr)) {           \
+            FailRequirement(#expr, __LINE__); \
+        }                        \
+    } while (false)
+
+class FakePlatformHost : public framekit::runtime::IPlatformHost {
+public:
+    bool Initialize() override {
+        initialize_calls += 1;
+        return initialize_result;
+    }
+
+    bool PumpEvents() override {
+        pump_calls += 1;
+        return pump_result;
+    }
+
+    bool Teardown() override {
+        teardown_calls += 1;
+        return teardown_result;
+    }
+
+    int initialize_calls = 0;
+    int pump_calls = 0;
+    int teardown_calls = 0;
+    bool initialize_result = true;
+    bool pump_result = true;
+    bool teardown_result = true;
+};
+
+class FakeWindowHost : public framekit::runtime::IWindowHost {
+public:
+    bool CreatePrimaryWindow(const framekit::runtime::WindowSpec& spec) override {
+        create_calls += 1;
+        last_window_title = spec.title;
+        return create_result;
+    }
+
+    bool PreRender() override {
+        pre_render_calls += 1;
+        return pre_render_result;
+    }
+
+    bool Render() override {
+        render_calls += 1;
+        return render_result;
+    }
+
+    bool PostRender() override {
+        post_render_calls += 1;
+        return post_render_result;
+    }
+
+    bool TeardownWindows() override {
+        teardown_calls += 1;
+        return teardown_result;
+    }
+
+    int create_calls = 0;
+    int pre_render_calls = 0;
+    int render_calls = 0;
+    int post_render_calls = 0;
+    int teardown_calls = 0;
+    bool create_result = true;
+    bool pre_render_result = true;
+    bool render_result = true;
+    bool post_render_result = true;
+    bool teardown_result = true;
+    std::string last_window_title;
+};
+
+void TestGuiRuntimeCallsPlatformAndWindowStages() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kGui;
+    policy.rendering_enabled = true;
+
+    auto platform = std::make_shared<FakePlatformHost>();
+    auto window = std::make_shared<FakeWindowHost>();
+
+    framekit::runtime::PlatformHostRuntime runtime;
+    runtime.SetPlatformHost(platform);
+    runtime.SetWindowHost(window);
+
+    framekit::runtime::WindowSpec spec;
+    spec.title = "framekit-test-window";
+
+    REQUIRE(runtime.Configure(policy, spec));
+    REQUIRE(runtime.Start());
+    REQUIRE(runtime.Tick());
+
+    REQUIRE(platform->initialize_calls == 1);
+    REQUIRE(platform->pump_calls == 1);
+    REQUIRE(window->create_calls == 1);
+    REQUIRE(window->last_window_title == "framekit-test-window");
+    REQUIRE(window->pre_render_calls == 1);
+    REQUIRE(window->render_calls == 1);
+    REQUIRE(window->post_render_calls == 1);
+
+    REQUIRE(runtime.Stop());
+    REQUIRE(!runtime.IsRunning());
+    REQUIRE(platform->teardown_calls == 1);
+    REQUIRE(window->teardown_calls == 1);
+}
+
+void TestHeadlessRuntimeSkipsWindowStages() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kHeadless;
+    policy.rendering_enabled = false;
+    policy.disabled_optional_stages = {"PreRender", "Render", "PostRender"};
+
+    auto platform = std::make_shared<FakePlatformHost>();
+
+    framekit::runtime::PlatformHostRuntime runtime;
+    runtime.SetPlatformHost(platform);
+
+    REQUIRE(runtime.Configure(policy));
+    REQUIRE(runtime.Start());
+    REQUIRE(runtime.Tick());
+    REQUIRE(runtime.Stop());
+
+    REQUIRE(platform->initialize_calls == 1);
+    REQUIRE(platform->pump_calls == 1);
+    REQUIRE(platform->teardown_calls == 1);
+
+    const auto& active = runtime.ActiveStages();
+    REQUIRE(std::find(active.begin(), active.end(), framekit::runtime::LoopStage::kPreRender) == active.end());
+    REQUIRE(std::find(active.begin(), active.end(), framekit::runtime::LoopStage::kRender) == active.end());
+    REQUIRE(std::find(active.begin(), active.end(), framekit::runtime::LoopStage::kPostRender) == active.end());
+}
+
+void TestStartFailsWithoutPlatformHost() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kHeadless;
+    policy.rendering_enabled = false;
+    policy.disabled_optional_stages = {"PreRender", "Render", "PostRender"};
+
+    framekit::runtime::PlatformHostRuntime runtime;
+    REQUIRE(runtime.Configure(policy));
+    REQUIRE(!runtime.Start());
+    REQUIRE(!runtime.LastError().empty());
+}
+
+void TestStartFailsWhenRenderStagesActiveWithoutWindowHost() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kGui;
+    policy.rendering_enabled = true;
+
+    auto platform = std::make_shared<FakePlatformHost>();
+
+    framekit::runtime::PlatformHostRuntime runtime;
+    runtime.SetPlatformHost(platform);
+    REQUIRE(runtime.Configure(policy));
+    REQUIRE(!runtime.Start());
+    REQUIRE(!runtime.LastError().empty());
+}
+
+void TestTickFailsOnPlatformPumpFailure() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kHeadless;
+    policy.rendering_enabled = false;
+    policy.disabled_optional_stages = {"PreRender", "Render", "PostRender"};
+
+    auto platform = std::make_shared<FakePlatformHost>();
+    platform->pump_result = false;
+
+    framekit::runtime::PlatformHostRuntime runtime;
+    runtime.SetPlatformHost(platform);
+
+    REQUIRE(runtime.Configure(policy));
+    REQUIRE(runtime.Start());
+    REQUIRE(!runtime.Tick());
+    REQUIRE(runtime.LastError().find("ProcessPlatformEvents") != std::string::npos);
+    REQUIRE(runtime.Stop());
+}
+
+void TestTickFailsOnWindowRenderFailure() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kGui;
+    policy.rendering_enabled = true;
+
+    auto platform = std::make_shared<FakePlatformHost>();
+    auto window = std::make_shared<FakeWindowHost>();
+    window->render_result = false;
+
+    framekit::runtime::PlatformHostRuntime runtime;
+    runtime.SetPlatformHost(platform);
+    runtime.SetWindowHost(window);
+
+    REQUIRE(runtime.Configure(policy));
+    REQUIRE(runtime.Start());
+    REQUIRE(!runtime.Tick());
+    REQUIRE(runtime.LastError().find("Render") != std::string::npos);
+    REQUIRE(runtime.Stop());
+}
+
+} // namespace
+
+int main() {
+    TestGuiRuntimeCallsPlatformAndWindowStages();
+    TestHeadlessRuntimeSkipsWindowStages();
+    TestStartFailsWithoutPlatformHost();
+    TestStartFailsWhenRenderStagesActiveWithoutWindowHost();
+    TestTickFailsOnPlatformPumpFailure();
+    TestTickFailsOnWindowRenderFailure();
+    return 0;
+}


### PR DESCRIPTION
Summary: adds a platform/window host runtime baseline integrated with loop-stage execution, including platform event pumping and render hook stages.\n\nValidation:\n- cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON\n- cmake --build build -j4\n- ctest --test-dir build --output-on-failure\n\nCloses #81