### PR TITLE
feat(core): add input normalization and routing runtime (#83)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(framekit_core STATIC
     src/lifecycle_state_machine.cpp
     src/loop_policy.cpp
     src/loop_stage_graph.cpp
+    src/input_routing_runtime.cpp
     src/platform_host_runtime.cpp
     src/module_graph.cpp
     src/event_bus.cpp

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,6 +10,7 @@ Current baseline includes:
 - loop profile and execution-policy validation contracts
 - loop stage graph runner with deterministic baseline-stage execution order
 - platform/window host baseline runtime integrated with stage-driven event pump and render hooks
+- input normalization and window-aware immediate routing runtime integrated with loop stages
 - service context freeze/lookup semantics and teardown ordering
 - module dependency DAG validation with deterministic startup/shutdown ordering
 - event bus immediate/deferred dispatch baseline with consume and priority semantics

--- a/include/framekit/framekit.hpp
+++ b/include/framekit/framekit.hpp
@@ -9,6 +9,7 @@
 #include "framekit/runtime/kernel_runtime.hpp"
 #include "framekit/runtime/lifecycle_state.hpp"
 #include "framekit/runtime/lifecycle_state_machine.hpp"
+#include "framekit/runtime/input_routing_runtime.hpp"
 #include "framekit/runtime/loop_policy.hpp"
 #include "framekit/runtime/loop_stage_graph.hpp"
 #include "framekit/runtime/platform_host_runtime.hpp"

--- a/include/framekit/runtime/input_routing_runtime.hpp
+++ b/include/framekit/runtime/input_routing_runtime.hpp
@@ -1,0 +1,153 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace framekit::runtime {
+
+enum class InputDevice : std::uint8_t {
+    kUnknown = 0,
+    kPointer = 1,
+    kKeyboard = 2,
+    kText = 3,
+};
+
+enum class InputAction : std::uint8_t {
+    kUnknown = 0,
+    kPointerMove = 1,
+    kPointerButtonDown = 2,
+    kPointerButtonUp = 3,
+    kKeyDown = 4,
+    kKeyUp = 5,
+    kTextInput = 6,
+};
+
+struct InputModifiers {
+    bool shift = false;
+    bool control = false;
+    bool alt = false;
+    bool meta = false;
+};
+
+struct RawInputEvent {
+    std::string backend_type;
+    std::string backend_payload;
+    InputDevice device = InputDevice::kUnknown;
+    InputAction action = InputAction::kUnknown;
+    std::uint64_t timestamp_ns = 0;
+    std::string source_id;
+    std::string window_id;
+    double pointer_x = 0.0;
+    double pointer_y = 0.0;
+    std::uint32_t key_code = 0;
+    std::string text;
+    InputModifiers modifiers;
+};
+
+struct NormalizedInputEvent {
+    InputDevice device = InputDevice::kUnknown;
+    InputAction action = InputAction::kUnknown;
+    std::uint64_t timestamp_ns = 0;
+    std::string source_id;
+    std::string window_id;
+    double pointer_x = 0.0;
+    double pointer_y = 0.0;
+    std::uint32_t key_code = 0;
+    std::string text;
+    InputModifiers modifiers;
+    std::string backend_extension;
+};
+
+class IInputNormalizer {
+public:
+    virtual ~IInputNormalizer() = default;
+
+    virtual bool Normalize(const RawInputEvent& raw_event, NormalizedInputEvent* normalized_event) const = 0;
+};
+
+class PassthroughInputNormalizer : public IInputNormalizer {
+public:
+    bool Normalize(const RawInputEvent& raw_event, NormalizedInputEvent* normalized_event) const override;
+};
+
+enum class MissingWindowTargetPolicy : std::uint8_t {
+    kDropWithDiagnostics = 0,
+    kFallbackToGlobal = 1,
+};
+
+struct InputDispatchResult {
+    std::size_t delivered_handlers = 0;
+    std::size_t dropped_events = 0;
+    bool consumed = false;
+};
+
+class InputRouter {
+public:
+    using HandlerId = std::uint64_t;
+    using InputHandler = std::function<bool(const NormalizedInputEvent& event)>;
+
+    HandlerId SubscribeWindow(std::string window_id, InputHandler handler);
+    HandlerId SubscribeGlobal(InputHandler handler);
+    bool UnsubscribeWindow(const std::string& window_id, HandlerId handler_id);
+    bool UnsubscribeGlobal(HandlerId handler_id);
+
+    void SetFocusedWindow(std::string window_id);
+    void SetPointerCaptureWindow(std::string window_id);
+    void ClearPointerCaptureWindow();
+    void SetMissingWindowTargetPolicy(MissingWindowTargetPolicy policy);
+
+    InputDispatchResult Route(const NormalizedInputEvent& event) const;
+
+private:
+    struct HandlerEntry {
+        HandlerId id = 0;
+        std::uint64_t sequence = 0;
+        InputHandler handler;
+    };
+
+    std::string ResolveTargetWindow(const NormalizedInputEvent& event) const;
+    InputDispatchResult RouteHandlers(
+        const std::vector<HandlerEntry>& handlers,
+        const NormalizedInputEvent& event) const;
+
+    std::unordered_map<std::string, std::vector<HandlerEntry>> window_handlers_;
+    std::vector<HandlerEntry> global_handlers_;
+    std::string focused_window_;
+    std::string pointer_capture_window_;
+    MissingWindowTargetPolicy missing_target_policy_ = MissingWindowTargetPolicy::kDropWithDiagnostics;
+    HandlerId next_handler_id_ = 1;
+    std::uint64_t next_sequence_ = 1;
+};
+
+class InputRoutingRuntime {
+public:
+    InputRoutingRuntime();
+
+    void SetNormalizer(std::shared_ptr<IInputNormalizer> normalizer);
+
+    InputRouter& Router();
+    const InputRouter& Router() const;
+
+    void EnqueueRawInput(RawInputEvent event);
+    bool NormalizePending();
+    InputDispatchResult DispatchImmediate();
+
+    std::size_t RawQueueSize() const;
+    std::size_t NormalizedQueueSize() const;
+    std::size_t DiscardPending();
+
+    const std::string& LastError() const;
+
+private:
+    std::shared_ptr<IInputNormalizer> normalizer_;
+    InputRouter router_;
+    std::vector<RawInputEvent> raw_queue_;
+    std::vector<NormalizedInputEvent> normalized_queue_;
+    std::string last_error_;
+};
+
+} // namespace framekit::runtime

--- a/include/framekit/runtime/platform_host_runtime.hpp
+++ b/include/framekit/runtime/platform_host_runtime.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "framekit/runtime/input_routing_runtime.hpp"
 #include "framekit/runtime/loop_policy.hpp"
 #include "framekit/runtime/loop_stage_graph.hpp"
 
@@ -41,6 +42,7 @@ class PlatformHostRuntime {
 public:
     void SetPlatformHost(std::shared_ptr<IPlatformHost> host);
     void SetWindowHost(std::shared_ptr<IWindowHost> host);
+    void SetInputRuntime(std::shared_ptr<InputRoutingRuntime> input_runtime);
 
     bool Configure(const LoopPolicy& policy, WindowSpec primary_window = {});
     bool Start();
@@ -56,13 +58,14 @@ public:
 
 private:
     bool HasActiveRenderStages() const;
-    void SetErrorForStage(LoopStage stage, const char* message);
+    void SetErrorForStage(LoopStage stage, const std::string& message);
 
     LoopStageGraphRunner loop_runner_;
     LoopPolicy policy_;
     WindowSpec primary_window_;
     std::shared_ptr<IPlatformHost> platform_host_;
     std::shared_ptr<IWindowHost> window_host_;
+    std::shared_ptr<InputRoutingRuntime> input_runtime_;
     bool configured_ = false;
     bool running_ = false;
     bool window_created_ = false;

--- a/src/input_routing_runtime.cpp
+++ b/src/input_routing_runtime.cpp
@@ -1,0 +1,254 @@
+#include "framekit/runtime/input_routing_runtime.hpp"
+
+#include <algorithm>
+#include <utility>
+
+namespace framekit::runtime {
+
+bool PassthroughInputNormalizer::Normalize(
+    const RawInputEvent& raw_event,
+    NormalizedInputEvent* normalized_event) const {
+    if (!normalized_event) {
+        return false;
+    }
+
+    normalized_event->device = raw_event.device;
+    normalized_event->action = raw_event.action;
+    normalized_event->timestamp_ns = raw_event.timestamp_ns;
+    normalized_event->source_id = raw_event.source_id;
+    normalized_event->window_id = raw_event.window_id;
+    normalized_event->pointer_x = raw_event.pointer_x;
+    normalized_event->pointer_y = raw_event.pointer_y;
+    normalized_event->key_code = raw_event.key_code;
+    normalized_event->text = raw_event.text;
+    normalized_event->modifiers = raw_event.modifiers;
+    normalized_event->backend_extension = raw_event.backend_payload;
+    return true;
+}
+
+InputRouter::HandlerId InputRouter::SubscribeWindow(std::string window_id, InputHandler handler) {
+    if (window_id.empty() || !handler) {
+        return 0;
+    }
+
+    const HandlerId id = next_handler_id_++;
+    window_handlers_[window_id].push_back(HandlerEntry{
+        .id = id,
+        .sequence = next_sequence_++,
+        .handler = std::move(handler),
+    });
+    return id;
+}
+
+InputRouter::HandlerId InputRouter::SubscribeGlobal(InputHandler handler) {
+    if (!handler) {
+        return 0;
+    }
+
+    const HandlerId id = next_handler_id_++;
+    global_handlers_.push_back(HandlerEntry{
+        .id = id,
+        .sequence = next_sequence_++,
+        .handler = std::move(handler),
+    });
+    return id;
+}
+
+bool InputRouter::UnsubscribeWindow(const std::string& window_id, HandlerId handler_id) {
+    auto found = window_handlers_.find(window_id);
+    if (found == window_handlers_.end()) {
+        return false;
+    }
+
+    auto& handlers = found->second;
+    const auto erase_it = std::remove_if(
+        handlers.begin(),
+        handlers.end(),
+        [handler_id](const HandlerEntry& entry) { return entry.id == handler_id; });
+
+    if (erase_it == handlers.end()) {
+        return false;
+    }
+
+    handlers.erase(erase_it, handlers.end());
+    if (handlers.empty()) {
+        window_handlers_.erase(found);
+    }
+
+    return true;
+}
+
+bool InputRouter::UnsubscribeGlobal(HandlerId handler_id) {
+    const auto erase_it = std::remove_if(
+        global_handlers_.begin(),
+        global_handlers_.end(),
+        [handler_id](const HandlerEntry& entry) { return entry.id == handler_id; });
+
+    if (erase_it == global_handlers_.end()) {
+        return false;
+    }
+
+    global_handlers_.erase(erase_it, global_handlers_.end());
+    return true;
+}
+
+void InputRouter::SetFocusedWindow(std::string window_id) {
+    focused_window_ = std::move(window_id);
+}
+
+void InputRouter::SetPointerCaptureWindow(std::string window_id) {
+    pointer_capture_window_ = std::move(window_id);
+}
+
+void InputRouter::ClearPointerCaptureWindow() {
+    pointer_capture_window_.clear();
+}
+
+void InputRouter::SetMissingWindowTargetPolicy(MissingWindowTargetPolicy policy) {
+    missing_target_policy_ = policy;
+}
+
+InputDispatchResult InputRouter::Route(const NormalizedInputEvent& event) const {
+    const auto target_window = ResolveTargetWindow(event);
+
+    if (!target_window.empty()) {
+        const auto found = window_handlers_.find(target_window);
+        if (found != window_handlers_.end()) {
+            auto result = RouteHandlers(found->second, event);
+            if (result.consumed) {
+                return result;
+            }
+
+            auto global_result = RouteHandlers(global_handlers_, event);
+            result.delivered_handlers += global_result.delivered_handlers;
+            result.dropped_events += global_result.dropped_events;
+            result.consumed = global_result.consumed;
+            return result;
+        }
+
+        if (missing_target_policy_ == MissingWindowTargetPolicy::kDropWithDiagnostics) {
+            return InputDispatchResult{
+                .delivered_handlers = 0,
+                .dropped_events = 1,
+                .consumed = false,
+            };
+        }
+    }
+
+    return RouteHandlers(global_handlers_, event);
+}
+
+std::string InputRouter::ResolveTargetWindow(const NormalizedInputEvent& event) const {
+    if (event.device == InputDevice::kPointer && !pointer_capture_window_.empty()) {
+        return pointer_capture_window_;
+    }
+
+    if (!event.window_id.empty()) {
+        return event.window_id;
+    }
+
+    if ((event.device == InputDevice::kKeyboard || event.device == InputDevice::kText) &&
+        !focused_window_.empty()) {
+        return focused_window_;
+    }
+
+    return {};
+}
+
+InputDispatchResult InputRouter::RouteHandlers(
+    const std::vector<HandlerEntry>& handlers,
+    const NormalizedInputEvent& event) const {
+    InputDispatchResult result;
+    for (const auto& handler_entry : handlers) {
+        result.delivered_handlers += 1;
+        if (handler_entry.handler && handler_entry.handler(event)) {
+            result.consumed = true;
+            break;
+        }
+    }
+
+    return result;
+}
+
+InputRoutingRuntime::InputRoutingRuntime()
+    : normalizer_(std::make_shared<PassthroughInputNormalizer>()) {}
+
+void InputRoutingRuntime::SetNormalizer(std::shared_ptr<IInputNormalizer> normalizer) {
+    normalizer_ = std::move(normalizer);
+}
+
+InputRouter& InputRoutingRuntime::Router() {
+    return router_;
+}
+
+const InputRouter& InputRoutingRuntime::Router() const {
+    return router_;
+}
+
+void InputRoutingRuntime::EnqueueRawInput(RawInputEvent event) {
+    raw_queue_.push_back(std::move(event));
+}
+
+bool InputRoutingRuntime::NormalizePending() {
+    if (!normalizer_) {
+        last_error_ = "input normalizer is not set";
+        return false;
+    }
+
+    std::vector<NormalizedInputEvent> normalized;
+    normalized.reserve(raw_queue_.size());
+
+    for (const auto& raw : raw_queue_) {
+        NormalizedInputEvent event;
+        if (!normalizer_->Normalize(raw, &event)) {
+            last_error_ = "failed to normalize raw input event";
+            return false;
+        }
+        normalized.push_back(std::move(event));
+    }
+
+    raw_queue_.clear();
+    for (auto& event : normalized) {
+        normalized_queue_.push_back(std::move(event));
+    }
+
+    last_error_.clear();
+    return true;
+}
+
+InputDispatchResult InputRoutingRuntime::DispatchImmediate() {
+    InputDispatchResult aggregate;
+
+    for (const auto& event : normalized_queue_) {
+        auto result = router_.Route(event);
+        aggregate.delivered_handlers += result.delivered_handlers;
+        aggregate.dropped_events += result.dropped_events;
+        if (result.consumed) {
+            aggregate.consumed = true;
+        }
+    }
+
+    normalized_queue_.clear();
+    return aggregate;
+}
+
+std::size_t InputRoutingRuntime::RawQueueSize() const {
+    return raw_queue_.size();
+}
+
+std::size_t InputRoutingRuntime::NormalizedQueueSize() const {
+    return normalized_queue_.size();
+}
+
+std::size_t InputRoutingRuntime::DiscardPending() {
+    const auto discarded = raw_queue_.size() + normalized_queue_.size();
+    raw_queue_.clear();
+    normalized_queue_.clear();
+    return discarded;
+}
+
+const std::string& InputRoutingRuntime::LastError() const {
+    return last_error_;
+}
+
+} // namespace framekit::runtime

--- a/src/platform_host_runtime.cpp
+++ b/src/platform_host_runtime.cpp
@@ -12,6 +12,10 @@ void PlatformHostRuntime::SetWindowHost(std::shared_ptr<IWindowHost> host) {
     window_host_ = std::move(host);
 }
 
+void PlatformHostRuntime::SetInputRuntime(std::shared_ptr<InputRoutingRuntime> input_runtime) {
+    input_runtime_ = std::move(input_runtime);
+}
+
 bool PlatformHostRuntime::Configure(const LoopPolicy& policy, WindowSpec primary_window) {
     if (running_) {
         last_error_ = "cannot configure platform runtime while running";
@@ -38,6 +42,29 @@ bool PlatformHostRuntime::Configure(const LoopPolicy& policy, WindowSpec primary
         if (!platform_host_->PumpEvents()) {
             SetErrorForStage(LoopStage::kProcessPlatformEvents, "platform host failed to pump events");
         }
+    });
+
+    loop_runner_.SetStageHandler(LoopStage::kNormalizeInput, [this]() {
+        if (!input_runtime_) {
+            return;
+        }
+
+        if (!input_runtime_->NormalizePending()) {
+            const auto& error = input_runtime_->LastError();
+            if (error.empty()) {
+                SetErrorForStage(LoopStage::kNormalizeInput, "input normalization failed");
+                return;
+            }
+            SetErrorForStage(LoopStage::kNormalizeInput, error);
+        }
+    });
+
+    loop_runner_.SetStageHandler(LoopStage::kDispatchImmediateEvents, [this]() {
+        if (!input_runtime_) {
+            return;
+        }
+
+        (void)input_runtime_->DispatchImmediate();
     });
 
     loop_runner_.SetStageHandler(LoopStage::kPreRender, [this]() {
@@ -191,7 +218,7 @@ bool PlatformHostRuntime::HasActiveRenderStages() const {
         std::find(active_stages.begin(), active_stages.end(), LoopStage::kPostRender) != active_stages.end();
 }
 
-void PlatformHostRuntime::SetErrorForStage(LoopStage stage, const char* message) {
+void PlatformHostRuntime::SetErrorForStage(LoopStage stage, const std::string& message) {
     frame_failed_ = true;
     if (!last_error_.empty()) {
         return;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,3 +25,10 @@ add_executable(framekit_platform_host_runtime_test
 
 target_link_libraries(framekit_platform_host_runtime_test PRIVATE FrameKit::Core)
 add_test(NAME framekit_platform_host_runtime_test COMMAND framekit_platform_host_runtime_test)
+
+add_executable(framekit_input_routing_runtime_test
+    test_input_routing_runtime.cpp
+)
+
+target_link_libraries(framekit_input_routing_runtime_test PRIVATE FrameKit::Core)
+add_test(NAME framekit_input_routing_runtime_test COMMAND framekit_input_routing_runtime_test)

--- a/tests/test_input_routing_runtime.cpp
+++ b/tests/test_input_routing_runtime.cpp
@@ -1,0 +1,251 @@
+#include "framekit/framekit.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace {
+
+[[noreturn]] void FailRequirement(const char* expr, int line) {
+    std::cerr << "Requirement failed at line " << line << ": " << expr << '\n';
+    std::abort();
+}
+
+#define REQUIRE(expr)            \
+    do {                         \
+        if (!(expr)) {           \
+            FailRequirement(#expr, __LINE__); \
+        }                        \
+    } while (false)
+
+class FakePlatformHost : public framekit::runtime::IPlatformHost {
+public:
+    bool Initialize() override {
+        initialize_calls += 1;
+        return true;
+    }
+
+    bool PumpEvents() override {
+        pump_calls += 1;
+        return true;
+    }
+
+    bool Teardown() override {
+        teardown_calls += 1;
+        return true;
+    }
+
+    int initialize_calls = 0;
+    int pump_calls = 0;
+    int teardown_calls = 0;
+};
+
+class FailingNormalizer : public framekit::runtime::IInputNormalizer {
+public:
+    bool Normalize(
+        const framekit::runtime::RawInputEvent& raw_event,
+        framekit::runtime::NormalizedInputEvent* normalized_event) const override {
+        if (raw_event.backend_type == "fail") {
+            return false;
+        }
+        if (!normalized_event) {
+            return false;
+        }
+
+        normalized_event->device = raw_event.device;
+        normalized_event->action = raw_event.action;
+        normalized_event->timestamp_ns = raw_event.timestamp_ns;
+        normalized_event->source_id = raw_event.source_id;
+        normalized_event->window_id = raw_event.window_id;
+        normalized_event->pointer_x = raw_event.pointer_x;
+        normalized_event->pointer_y = raw_event.pointer_y;
+        normalized_event->key_code = raw_event.key_code;
+        normalized_event->text = raw_event.text;
+        normalized_event->modifiers = raw_event.modifiers;
+        normalized_event->backend_extension = raw_event.backend_payload;
+        return true;
+    }
+};
+
+void TestFocusedKeyboardRouting() {
+    framekit::runtime::InputRoutingRuntime runtime;
+
+    int focused_calls = 0;
+    runtime.Router().SetFocusedWindow("main-window");
+    runtime.Router().SubscribeWindow(
+        "main-window",
+        [&focused_calls](const framekit::runtime::NormalizedInputEvent& event) {
+            (void)event;
+            focused_calls += 1;
+            return true;
+        });
+
+    framekit::runtime::RawInputEvent raw;
+    raw.device = framekit::runtime::InputDevice::kKeyboard;
+    raw.action = framekit::runtime::InputAction::kKeyDown;
+    raw.key_code = 65;
+    raw.timestamp_ns = 100;
+    raw.source_id = "keyboard-1";
+    runtime.EnqueueRawInput(raw);
+
+    REQUIRE(runtime.NormalizePending());
+    const auto dispatched = runtime.DispatchImmediate();
+    REQUIRE(dispatched.delivered_handlers == 1);
+    REQUIRE(dispatched.dropped_events == 0);
+    REQUIRE(dispatched.consumed);
+    REQUIRE(focused_calls == 1);
+}
+
+void TestPointerCaptureOverridesEventTarget() {
+    framekit::runtime::InputRoutingRuntime runtime;
+
+    int capture_calls = 0;
+    runtime.Router().SetPointerCaptureWindow("capture-window");
+    runtime.Router().SubscribeWindow(
+        "capture-window",
+        [&capture_calls](const framekit::runtime::NormalizedInputEvent& event) {
+            (void)event;
+            capture_calls += 1;
+            return true;
+        });
+
+    framekit::runtime::RawInputEvent raw;
+    raw.device = framekit::runtime::InputDevice::kPointer;
+    raw.action = framekit::runtime::InputAction::kPointerMove;
+    raw.window_id = "other-window";
+    runtime.EnqueueRawInput(raw);
+
+    REQUIRE(runtime.NormalizePending());
+    const auto dispatched = runtime.DispatchImmediate();
+    REQUIRE(dispatched.delivered_handlers == 1);
+    REQUIRE(dispatched.dropped_events == 0);
+    REQUIRE(capture_calls == 1);
+}
+
+void TestMissingTargetDropPolicy() {
+    framekit::runtime::InputRoutingRuntime runtime;
+
+    int global_calls = 0;
+    runtime.Router().SubscribeGlobal(
+        [&global_calls](const framekit::runtime::NormalizedInputEvent& event) {
+            (void)event;
+            global_calls += 1;
+            return false;
+        });
+
+    framekit::runtime::RawInputEvent raw;
+    raw.device = framekit::runtime::InputDevice::kPointer;
+    raw.action = framekit::runtime::InputAction::kPointerMove;
+    raw.window_id = "missing-window";
+    runtime.EnqueueRawInput(raw);
+
+    REQUIRE(runtime.NormalizePending());
+    const auto dispatched = runtime.DispatchImmediate();
+    REQUIRE(dispatched.delivered_handlers == 0);
+    REQUIRE(dispatched.dropped_events == 1);
+    REQUIRE(!dispatched.consumed);
+    REQUIRE(global_calls == 0);
+}
+
+void TestMissingTargetFallbackToGlobalPolicy() {
+    framekit::runtime::InputRoutingRuntime runtime;
+
+    runtime.Router().SetMissingWindowTargetPolicy(framekit::runtime::MissingWindowTargetPolicy::kFallbackToGlobal);
+
+    int global_calls = 0;
+    runtime.Router().SubscribeGlobal(
+        [&global_calls](const framekit::runtime::NormalizedInputEvent& event) {
+            (void)event;
+            global_calls += 1;
+            return false;
+        });
+
+    framekit::runtime::RawInputEvent raw;
+    raw.device = framekit::runtime::InputDevice::kPointer;
+    raw.action = framekit::runtime::InputAction::kPointerMove;
+    raw.window_id = "missing-window";
+    runtime.EnqueueRawInput(raw);
+
+    REQUIRE(runtime.NormalizePending());
+    const auto dispatched = runtime.DispatchImmediate();
+    REQUIRE(dispatched.delivered_handlers == 1);
+    REQUIRE(dispatched.dropped_events == 0);
+    REQUIRE(global_calls == 1);
+}
+
+void TestNormalizeFailurePropagatesToPlatformRuntime() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kHeadless;
+    policy.rendering_enabled = false;
+    policy.disabled_optional_stages = {"PreRender", "Render", "PostRender"};
+
+    auto platform = std::make_shared<FakePlatformHost>();
+    auto input_runtime = std::make_shared<framekit::runtime::InputRoutingRuntime>();
+    input_runtime->SetNormalizer(std::make_shared<FailingNormalizer>());
+
+    framekit::runtime::RawInputEvent raw;
+    raw.backend_type = "fail";
+    raw.device = framekit::runtime::InputDevice::kKeyboard;
+    raw.action = framekit::runtime::InputAction::kKeyDown;
+    input_runtime->EnqueueRawInput(raw);
+
+    framekit::runtime::PlatformHostRuntime runtime;
+    runtime.SetPlatformHost(platform);
+    runtime.SetInputRuntime(input_runtime);
+
+    REQUIRE(runtime.Configure(policy));
+    REQUIRE(runtime.Start());
+    REQUIRE(!runtime.Tick());
+    REQUIRE(runtime.LastError().find("NormalizeInput") != std::string::npos);
+    REQUIRE(runtime.Stop());
+}
+
+void TestPlatformRuntimeDispatchesImmediateInput() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kHeadless;
+    policy.rendering_enabled = false;
+    policy.disabled_optional_stages = {"PreRender", "Render", "PostRender"};
+
+    auto platform = std::make_shared<FakePlatformHost>();
+    auto input_runtime = std::make_shared<framekit::runtime::InputRoutingRuntime>();
+
+    int focused_calls = 0;
+    input_runtime->Router().SetFocusedWindow("editor");
+    input_runtime->Router().SubscribeWindow(
+        "editor",
+        [&focused_calls](const framekit::runtime::NormalizedInputEvent& event) {
+            (void)event;
+            focused_calls += 1;
+            return true;
+        });
+
+    framekit::runtime::RawInputEvent raw;
+    raw.device = framekit::runtime::InputDevice::kKeyboard;
+    raw.action = framekit::runtime::InputAction::kKeyDown;
+    raw.key_code = 70;
+    input_runtime->EnqueueRawInput(raw);
+
+    framekit::runtime::PlatformHostRuntime runtime;
+    runtime.SetPlatformHost(platform);
+    runtime.SetInputRuntime(input_runtime);
+
+    REQUIRE(runtime.Configure(policy));
+    REQUIRE(runtime.Start());
+    REQUIRE(runtime.Tick());
+    REQUIRE(focused_calls == 1);
+    REQUIRE(platform->pump_calls == 1);
+    REQUIRE(runtime.Stop());
+}
+
+} // namespace
+
+int main() {
+    TestFocusedKeyboardRouting();
+    TestPointerCaptureOverridesEventTarget();
+    TestMissingTargetDropPolicy();
+    TestMissingTargetFallbackToGlobalPolicy();
+    TestNormalizeFailurePropagatesToPlatformRuntime();
+    TestPlatformRuntimeDispatchesImmediateInput();
+    return 0;
+}


### PR DESCRIPTION
Summary: adds input normalization and window-aware immediate routing runtime, then wires NormalizeInput/DispatchImmediateEvents loop stages into platform runtime hooks. Includes contract tests for focus/capture routing, missing-target policy behavior, and platform-loop integration.\n\nValidation:\n- cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON\n- cmake --build build -j4\n- ctest --test-dir build --output-on-failure\n\nCloses #83