### PR TITLE
feat(core): enforce profile-aware fault policy escalation (#85)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(framekit_core STATIC
     src/multiprocess_runtime.cpp
     src/lifecycle_state_machine.cpp
     src/loop_policy.cpp
+    src/fault_policy_runtime.cpp
     src/loop_stage_graph.cpp
     src/input_routing_runtime.cpp
     src/platform_host_runtime.cpp

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -8,6 +8,7 @@ Current baseline includes:
 - multiprocess runtime skeleton
 - lifecycle state machine and kernel runtime start/stop orchestration
 - loop profile and execution-policy validation contracts
+- profile-aware fault-policy runtime with bounded degrade budgets and fail-fast escalation
 - loop stage graph runner with deterministic baseline-stage execution order
 - platform/window host baseline runtime integrated with stage-driven event pump and render hooks
 - input normalization and window-aware immediate routing runtime integrated with loop stages

--- a/include/framekit/framekit.hpp
+++ b/include/framekit/framekit.hpp
@@ -7,6 +7,7 @@
 #include "framekit/process_topology.hpp"
 #include "framekit/runtime/multiprocess_runtime.hpp"
 #include "framekit/runtime/kernel_runtime.hpp"
+#include "framekit/runtime/fault_policy_runtime.hpp"
 #include "framekit/runtime/lifecycle_state.hpp"
 #include "framekit/runtime/lifecycle_state_machine.hpp"
 #include "framekit/runtime/input_routing_runtime.hpp"

--- a/include/framekit/runtime/fault_policy_runtime.hpp
+++ b/include/framekit/runtime/fault_policy_runtime.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "framekit/runtime/loop_policy.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace framekit::runtime {
+
+enum class FaultClass : std::uint8_t {
+    kBootstrap = 0,
+    kModule = 1,
+    kEvent = 2,
+    kRender = 3,
+    kTiming = 4,
+    kShutdown = 5,
+};
+
+const char* FaultClassName(FaultClass fault_class);
+
+enum class FaultDisposition : std::uint8_t {
+    kFailFast = 0,
+    kDegrade = 1,
+};
+
+struct FaultPolicyLimits {
+    std::uint32_t module_optional_limit = 1;
+    std::uint32_t event_noncritical_limit = 3;
+    std::uint32_t render_isolation_limit = 2;
+    std::uint32_t timing_overrun_limit = 3;
+    std::uint32_t shutdown_nonfatal_limit = 1;
+};
+
+struct FaultPolicyContext {
+    FaultClass fault_class = FaultClass::kBootstrap;
+    bool invariant_breach = false;
+    bool contract_violation = false;
+    bool required_module = false;
+    bool fatal_shutdown_violation = false;
+};
+
+struct FaultPolicyDecision {
+    FaultDisposition disposition = FaultDisposition::kFailFast;
+    bool escalated = false;
+    bool consumed_budget = false;
+    std::uint32_t observed_count = 0;
+    std::string reason;
+};
+
+class FaultPolicyRuntime {
+public:
+    bool Configure(const LoopPolicy& policy, FaultPolicyLimits limits = {});
+    FaultPolicyDecision Evaluate(const FaultPolicyContext& context);
+
+    void Reset();
+
+    bool IsConfigured() const;
+    const LoopPolicy& Policy() const;
+    const FaultPolicyLimits& Limits() const;
+    std::uint32_t FaultCount(FaultClass fault_class) const;
+    const std::string& LastDecisionReason() const;
+
+private:
+    static constexpr std::size_t kFaultClassCount = 6;
+
+    std::uint32_t IncrementAndGet(FaultClass fault_class);
+    FaultPolicyDecision FailFast(std::string reason, bool escalated, std::uint32_t observed_count);
+    FaultPolicyDecision DegradeWithLimit(
+        FaultClass fault_class,
+        std::uint32_t limit,
+        const char* degrade_reason,
+        const char* escalation_reason);
+
+    LoopPolicy policy_;
+    FaultPolicyLimits limits_;
+    std::array<std::uint32_t, kFaultClassCount> counters_{};
+    bool configured_ = false;
+    std::string last_decision_reason_;
+};
+
+} // namespace framekit::runtime

--- a/src/fault_policy_runtime.cpp
+++ b/src/fault_policy_runtime.cpp
@@ -1,0 +1,218 @@
+#include "framekit/runtime/fault_policy_runtime.hpp"
+
+#include <array>
+#include <string>
+
+namespace framekit::runtime {
+
+namespace {
+
+std::size_t FaultClassIndex(FaultClass fault_class) {
+    return static_cast<std::size_t>(fault_class);
+}
+
+std::string WithBudgetContext(
+    const char* reason,
+    std::uint32_t observed_count,
+    std::uint32_t limit) {
+    std::string message = reason;
+    message += " (";
+    message += std::to_string(observed_count);
+    message += "/";
+    message += std::to_string(limit);
+    message += ")";
+    return message;
+}
+
+} // namespace
+
+const char* FaultClassName(FaultClass fault_class) {
+    static constexpr std::array<const char*, 6> kNames = {
+        "Bootstrap",
+        "Module",
+        "Event",
+        "Render",
+        "Timing",
+        "Shutdown",
+    };
+
+    const auto index = FaultClassIndex(fault_class);
+    if (index >= kNames.size()) {
+        return "UnknownFaultClass";
+    }
+
+    return kNames[index];
+}
+
+bool FaultPolicyRuntime::Configure(const LoopPolicy& policy, FaultPolicyLimits limits) {
+    const auto validation = ValidateLoopPolicy(policy);
+    if (!validation.valid) {
+        configured_ = false;
+        last_decision_reason_ = "cannot configure fault policy runtime: ";
+        last_decision_reason_ += validation.reason;
+        return false;
+    }
+
+    policy_ = policy;
+    limits_ = limits;
+    counters_.fill(0);
+    configured_ = true;
+    last_decision_reason_.clear();
+    return true;
+}
+
+FaultPolicyDecision FaultPolicyRuntime::Evaluate(const FaultPolicyContext& context) {
+    if (!configured_) {
+        return FailFast("fault policy runtime is not configured", false, 0);
+    }
+
+    if (context.invariant_breach) {
+        const auto observed = IncrementAndGet(context.fault_class);
+        return FailFast("always-fail-fast invariant breached", false, observed);
+    }
+
+    if (policy_.profile == LoopProfile::kDeterministicHost) {
+        const auto observed = IncrementAndGet(context.fault_class);
+        return FailFast("deterministic host profile enforces fail-fast fault handling", false, observed);
+    }
+
+    switch (context.fault_class) {
+        case FaultClass::kBootstrap: {
+            const auto observed = IncrementAndGet(FaultClass::kBootstrap);
+            return FailFast("bootstrap faults are always fail-fast", false, observed);
+        }
+        case FaultClass::kModule:
+            if (context.required_module || context.contract_violation) {
+                const auto observed = IncrementAndGet(FaultClass::kModule);
+                return FailFast("required or invalid module fault requires fail-fast", false, observed);
+            }
+            return DegradeWithLimit(
+                FaultClass::kModule,
+                limits_.module_optional_limit,
+                "optional module fault degraded",
+                "optional module degrade limit exceeded; escalating to fail-fast");
+        case FaultClass::kEvent:
+            if (context.contract_violation) {
+                const auto observed = IncrementAndGet(FaultClass::kEvent);
+                return FailFast("event contract violation requires fail-fast", false, observed);
+            }
+            return DegradeWithLimit(
+                FaultClass::kEvent,
+                limits_.event_noncritical_limit,
+                "noncritical event fault degraded",
+                "event degrade limit exceeded; escalating to fail-fast");
+        case FaultClass::kRender:
+            if (!policy_.rendering_enabled) {
+                const auto observed = IncrementAndGet(FaultClass::kRender);
+                return FailFast("render degrade unavailable when rendering is disabled", false, observed);
+            }
+            if (context.contract_violation) {
+                const auto observed = IncrementAndGet(FaultClass::kRender);
+                return FailFast("render contract violation requires fail-fast", false, observed);
+            }
+            return DegradeWithLimit(
+                FaultClass::kRender,
+                limits_.render_isolation_limit,
+                "render fault degraded via isolation",
+                "render degrade limit exceeded; escalating to fail-fast");
+        case FaultClass::kTiming:
+            if (policy_.overrun_mode == OverrunMode::kFailFast || context.contract_violation) {
+                const auto observed = IncrementAndGet(FaultClass::kTiming);
+                return FailFast("timing fault requires fail-fast under active policy", false, observed);
+            }
+            return DegradeWithLimit(
+                FaultClass::kTiming,
+                limits_.timing_overrun_limit,
+                "timing fault degraded via bounded catch-up/slip",
+                "timing degrade limit exceeded; escalating to fail-fast");
+        case FaultClass::kShutdown:
+            if (context.fatal_shutdown_violation || context.contract_violation) {
+                const auto observed = IncrementAndGet(FaultClass::kShutdown);
+                return FailFast("fatal shutdown fault requires fail-fast", false, observed);
+            }
+            return DegradeWithLimit(
+                FaultClass::kShutdown,
+                limits_.shutdown_nonfatal_limit,
+                "non-fatal shutdown fault degraded",
+                "shutdown degrade limit exceeded; escalating to fail-fast");
+    }
+
+    const auto observed = IncrementAndGet(context.fault_class);
+    return FailFast("unknown fault class", false, observed);
+}
+
+void FaultPolicyRuntime::Reset() {
+    counters_.fill(0);
+    last_decision_reason_.clear();
+}
+
+bool FaultPolicyRuntime::IsConfigured() const {
+    return configured_;
+}
+
+const LoopPolicy& FaultPolicyRuntime::Policy() const {
+    return policy_;
+}
+
+const FaultPolicyLimits& FaultPolicyRuntime::Limits() const {
+    return limits_;
+}
+
+std::uint32_t FaultPolicyRuntime::FaultCount(FaultClass fault_class) const {
+    const auto index = FaultClassIndex(fault_class);
+    if (index >= counters_.size()) {
+        return 0;
+    }
+    return counters_[index];
+}
+
+const std::string& FaultPolicyRuntime::LastDecisionReason() const {
+    return last_decision_reason_;
+}
+
+std::uint32_t FaultPolicyRuntime::IncrementAndGet(FaultClass fault_class) {
+    const auto index = FaultClassIndex(fault_class);
+    if (index >= counters_.size()) {
+        return 0;
+    }
+
+    counters_[index] += 1;
+    return counters_[index];
+}
+
+FaultPolicyDecision FaultPolicyRuntime::FailFast(
+    std::string reason,
+    bool escalated,
+    std::uint32_t observed_count) {
+    last_decision_reason_ = std::move(reason);
+    return FaultPolicyDecision{
+        .disposition = FaultDisposition::kFailFast,
+        .escalated = escalated,
+        .consumed_budget = false,
+        .observed_count = observed_count,
+        .reason = last_decision_reason_,
+    };
+}
+
+FaultPolicyDecision FaultPolicyRuntime::DegradeWithLimit(
+    FaultClass fault_class,
+    std::uint32_t limit,
+    const char* degrade_reason,
+    const char* escalation_reason) {
+    const auto observed = IncrementAndGet(fault_class);
+
+    if (limit == 0 || observed > limit) {
+        return FailFast(escalation_reason, true, observed);
+    }
+
+    last_decision_reason_ = WithBudgetContext(degrade_reason, observed, limit);
+    return FaultPolicyDecision{
+        .disposition = FaultDisposition::kDegrade,
+        .escalated = false,
+        .consumed_budget = true,
+        .observed_count = observed,
+        .reason = last_decision_reason_,
+    };
+}
+
+} // namespace framekit::runtime

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,3 +32,10 @@ add_executable(framekit_input_routing_runtime_test
 
 target_link_libraries(framekit_input_routing_runtime_test PRIVATE FrameKit::Core)
 add_test(NAME framekit_input_routing_runtime_test COMMAND framekit_input_routing_runtime_test)
+
+add_executable(framekit_fault_policy_runtime_test
+    test_fault_policy_runtime.cpp
+)
+
+target_link_libraries(framekit_fault_policy_runtime_test PRIVATE FrameKit::Core)
+add_test(NAME framekit_fault_policy_runtime_test COMMAND framekit_fault_policy_runtime_test)

--- a/tests/test_fault_policy_runtime.cpp
+++ b/tests/test_fault_policy_runtime.cpp
@@ -1,0 +1,205 @@
+#include "framekit/framekit.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace {
+
+[[noreturn]] void FailRequirement(const char* expr, int line) {
+    std::cerr << "Requirement failed at line " << line << ": " << expr << '\n';
+    std::abort();
+}
+
+#define REQUIRE(expr)            \
+    do {                         \
+        if (!(expr)) {           \
+            FailRequirement(#expr, __LINE__); \
+        }                        \
+    } while (false)
+
+framekit::runtime::LoopPolicy MakeGuiPolicy() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kGui;
+    policy.rendering_enabled = true;
+    return policy;
+}
+
+framekit::runtime::LoopPolicy MakeHeadlessPolicy() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kHeadless;
+    policy.rendering_enabled = false;
+    policy.disabled_optional_stages = {
+        "PreRender",
+        "Render",
+        "PostRender",
+    };
+    return policy;
+}
+
+framekit::runtime::LoopPolicy MakeDeterministicPolicy() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kDeterministicHost;
+    policy.timing_mode = framekit::runtime::TimingMode::kFixedDelta;
+    policy.overrun_mode = framekit::runtime::OverrunMode::kFailFast;
+    policy.rendering_enabled = false;
+    policy.disabled_optional_stages = {
+        "PreRender",
+        "Render",
+        "PostRender",
+    };
+    return policy;
+}
+
+void TestConfigurationRejectsInvalidPolicy() {
+    framekit::runtime::FaultPolicyRuntime runtime;
+
+    framekit::runtime::LoopPolicy invalid;
+    invalid.profile = framekit::runtime::LoopProfile::kHeadless;
+    invalid.rendering_enabled = false;
+
+    REQUIRE(!runtime.Configure(invalid));
+    REQUIRE(!runtime.IsConfigured());
+}
+
+void TestDeterministicProfileAlwaysFailFast() {
+    framekit::runtime::FaultPolicyRuntime runtime;
+    REQUIRE(runtime.Configure(MakeDeterministicPolicy()));
+
+    const auto decision = runtime.Evaluate(framekit::runtime::FaultPolicyContext{
+        .fault_class = framekit::runtime::FaultClass::kEvent,
+    });
+
+    REQUIRE(decision.disposition == framekit::runtime::FaultDisposition::kFailFast);
+    REQUIRE(!decision.escalated);
+    REQUIRE(decision.reason.find("deterministic host profile") != std::string::npos);
+    REQUIRE(runtime.FaultCount(framekit::runtime::FaultClass::kEvent) == 1);
+}
+
+void TestModuleDegradeEscalatesAfterLimit() {
+    framekit::runtime::FaultPolicyRuntime runtime;
+    framekit::runtime::FaultPolicyLimits limits;
+    limits.module_optional_limit = 2;
+    REQUIRE(runtime.Configure(MakeGuiPolicy(), limits));
+
+    const auto first = runtime.Evaluate(framekit::runtime::FaultPolicyContext{
+        .fault_class = framekit::runtime::FaultClass::kModule,
+    });
+    REQUIRE(first.disposition == framekit::runtime::FaultDisposition::kDegrade);
+    REQUIRE(!first.escalated);
+    REQUIRE(first.consumed_budget);
+    REQUIRE(first.observed_count == 1);
+
+    const auto second = runtime.Evaluate(framekit::runtime::FaultPolicyContext{
+        .fault_class = framekit::runtime::FaultClass::kModule,
+    });
+    REQUIRE(second.disposition == framekit::runtime::FaultDisposition::kDegrade);
+    REQUIRE(second.observed_count == 2);
+
+    const auto third = runtime.Evaluate(framekit::runtime::FaultPolicyContext{
+        .fault_class = framekit::runtime::FaultClass::kModule,
+    });
+    REQUIRE(third.disposition == framekit::runtime::FaultDisposition::kFailFast);
+    REQUIRE(third.escalated);
+    REQUIRE(third.observed_count == 3);
+    REQUIRE(runtime.FaultCount(framekit::runtime::FaultClass::kModule) == 3);
+}
+
+void TestRequiredModuleFaultAlwaysFailFast() {
+    framekit::runtime::FaultPolicyRuntime runtime;
+    REQUIRE(runtime.Configure(MakeGuiPolicy()));
+
+    const auto decision = runtime.Evaluate(framekit::runtime::FaultPolicyContext{
+        .fault_class = framekit::runtime::FaultClass::kModule,
+        .required_module = true,
+    });
+
+    REQUIRE(decision.disposition == framekit::runtime::FaultDisposition::kFailFast);
+    REQUIRE(decision.reason.find("required or invalid module") != std::string::npos);
+}
+
+void TestRenderDegradeUnavailableWhenRenderingDisabled() {
+    framekit::runtime::FaultPolicyRuntime runtime;
+    REQUIRE(runtime.Configure(MakeHeadlessPolicy()));
+
+    const auto decision = runtime.Evaluate(framekit::runtime::FaultPolicyContext{
+        .fault_class = framekit::runtime::FaultClass::kRender,
+    });
+
+    REQUIRE(decision.disposition == framekit::runtime::FaultDisposition::kFailFast);
+    REQUIRE(decision.reason.find("render degrade unavailable") != std::string::npos);
+}
+
+void TestEventContractViolationAlwaysFailFast() {
+    framekit::runtime::FaultPolicyRuntime runtime;
+    REQUIRE(runtime.Configure(MakeGuiPolicy()));
+
+    const auto decision = runtime.Evaluate(framekit::runtime::FaultPolicyContext{
+        .fault_class = framekit::runtime::FaultClass::kEvent,
+        .contract_violation = true,
+    });
+
+    REQUIRE(decision.disposition == framekit::runtime::FaultDisposition::kFailFast);
+    REQUIRE(decision.reason.find("event contract violation") != std::string::npos);
+}
+
+void TestTimingFailFastWhenOverrunModeIsFailFast() {
+    framekit::runtime::FaultPolicyRuntime runtime;
+    auto policy = MakeGuiPolicy();
+    policy.overrun_mode = framekit::runtime::OverrunMode::kFailFast;
+    REQUIRE(runtime.Configure(policy));
+
+    const auto decision = runtime.Evaluate(framekit::runtime::FaultPolicyContext{
+        .fault_class = framekit::runtime::FaultClass::kTiming,
+    });
+
+    REQUIRE(decision.disposition == framekit::runtime::FaultDisposition::kFailFast);
+    REQUIRE(decision.reason.find("timing fault requires fail-fast") != std::string::npos);
+}
+
+void TestInvariantBreachAlwaysFailFast() {
+    framekit::runtime::FaultPolicyRuntime runtime;
+    REQUIRE(runtime.Configure(MakeGuiPolicy()));
+
+    const auto decision = runtime.Evaluate(framekit::runtime::FaultPolicyContext{
+        .fault_class = framekit::runtime::FaultClass::kShutdown,
+        .invariant_breach = true,
+    });
+
+    REQUIRE(decision.disposition == framekit::runtime::FaultDisposition::kFailFast);
+    REQUIRE(decision.reason.find("always-fail-fast invariant") != std::string::npos);
+}
+
+void TestShutdownDegradeEscalatesAfterLimit() {
+    framekit::runtime::FaultPolicyRuntime runtime;
+    framekit::runtime::FaultPolicyLimits limits;
+    limits.shutdown_nonfatal_limit = 1;
+    REQUIRE(runtime.Configure(MakeGuiPolicy(), limits));
+
+    const auto first = runtime.Evaluate(framekit::runtime::FaultPolicyContext{
+        .fault_class = framekit::runtime::FaultClass::kShutdown,
+    });
+    REQUIRE(first.disposition == framekit::runtime::FaultDisposition::kDegrade);
+
+    const auto second = runtime.Evaluate(framekit::runtime::FaultPolicyContext{
+        .fault_class = framekit::runtime::FaultClass::kShutdown,
+    });
+    REQUIRE(second.disposition == framekit::runtime::FaultDisposition::kFailFast);
+    REQUIRE(second.escalated);
+    REQUIRE(second.reason.find("shutdown degrade limit exceeded") != std::string::npos);
+}
+
+} // namespace
+
+int main() {
+    TestConfigurationRejectsInvalidPolicy();
+    TestDeterministicProfileAlwaysFailFast();
+    TestModuleDegradeEscalatesAfterLimit();
+    TestRequiredModuleFaultAlwaysFailFast();
+    TestRenderDegradeUnavailableWhenRenderingDisabled();
+    TestEventContractViolationAlwaysFailFast();
+    TestTimingFailFastWhenOverrunModeIsFailFast();
+    TestInvariantBreachAlwaysFailFast();
+    TestShutdownDegradeEscalatesAfterLimit();
+    return 0;
+}


### PR DESCRIPTION
Summary:\n- add  with profile-aware fault decisions for bootstrap/module/event/render/timing/shutdown\n- implement bounded degrade budgets with automatic escalation to fail-fast when limits are exceeded\n- enforce deterministic-host strict fail-fast behavior and always-fail-fast invariant handling\n- add contract tests for matrix-aligned decisions and escalation behavior\n\nValidation:\n- cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON\n- cmake --build build -j4\n- ctest --test-dir build --output-on-failure\n\nCloses #85