### PR TITLE
feat(core): integrate platform stage faults with policy runtime (#88)

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -8,7 +8,7 @@ Current baseline includes:
 - multiprocess runtime skeleton
 - lifecycle state machine and kernel runtime start/stop orchestration
 - loop profile and execution-policy validation contracts
-- profile-aware fault-policy runtime with bounded degrade budgets and fail-fast escalation
+- profile-aware fault-policy runtime with bounded degrade budgets and fail-fast escalation integrated into platform stage-failure handling
 - loop stage graph runner with deterministic baseline-stage execution order
 - platform/window host baseline runtime integrated with stage-driven event pump and render hooks
 - input normalization and window-aware immediate routing runtime integrated with loop stages

--- a/include/framekit/runtime/platform_host_runtime.hpp
+++ b/include/framekit/runtime/platform_host_runtime.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "framekit/runtime/fault_policy_runtime.hpp"
 #include "framekit/runtime/input_routing_runtime.hpp"
 #include "framekit/runtime/loop_policy.hpp"
 #include "framekit/runtime/loop_stage_graph.hpp"
@@ -58,7 +59,10 @@ public:
 
 private:
     bool HasActiveRenderStages() const;
-    void SetErrorForStage(LoopStage stage, const std::string& message);
+    void HandleStageFault(
+        LoopStage stage,
+        FaultPolicyContext context,
+        const std::string& message);
 
     LoopStageGraphRunner loop_runner_;
     LoopPolicy policy_;
@@ -66,6 +70,7 @@ private:
     std::shared_ptr<IPlatformHost> platform_host_;
     std::shared_ptr<IWindowHost> window_host_;
     std::shared_ptr<InputRoutingRuntime> input_runtime_;
+    FaultPolicyRuntime fault_policy_;
     bool configured_ = false;
     bool running_ = false;
     bool window_created_ = false;

--- a/src/platform_host_runtime.cpp
+++ b/src/platform_host_runtime.cpp
@@ -32,15 +32,35 @@ bool PlatformHostRuntime::Configure(const LoopPolicy& policy, WindowSpec primary
     policy_ = policy;
     primary_window_ = std::move(primary_window);
 
+    if (!fault_policy_.Configure(policy_)) {
+        last_error_ = fault_policy_.LastDecisionReason();
+        configured_ = false;
+        return false;
+    }
+
+    fault_policy_.Reset();
+
     loop_runner_.ClearStageHandlers();
     loop_runner_.SetStageHandler(LoopStage::kProcessPlatformEvents, [this]() {
         if (!platform_host_) {
-            SetErrorForStage(LoopStage::kProcessPlatformEvents, "platform host is not set");
+            HandleStageFault(
+                LoopStage::kProcessPlatformEvents,
+                FaultPolicyContext{
+                    .fault_class = FaultClass::kEvent,
+                    .contract_violation = true,
+                },
+                "platform host is not set");
             return;
         }
 
         if (!platform_host_->PumpEvents()) {
-            SetErrorForStage(LoopStage::kProcessPlatformEvents, "platform host failed to pump events");
+            HandleStageFault(
+                LoopStage::kProcessPlatformEvents,
+                FaultPolicyContext{
+                    .fault_class = FaultClass::kEvent,
+                    .contract_violation = true,
+                },
+                "platform host failed to pump events");
         }
     });
 
@@ -52,10 +72,23 @@ bool PlatformHostRuntime::Configure(const LoopPolicy& policy, WindowSpec primary
         if (!input_runtime_->NormalizePending()) {
             const auto& error = input_runtime_->LastError();
             if (error.empty()) {
-                SetErrorForStage(LoopStage::kNormalizeInput, "input normalization failed");
+                HandleStageFault(
+                    LoopStage::kNormalizeInput,
+                    FaultPolicyContext{
+                        .fault_class = FaultClass::kEvent,
+                        .contract_violation = true,
+                    },
+                    "input normalization failed");
                 return;
             }
-            SetErrorForStage(LoopStage::kNormalizeInput, error);
+
+            HandleStageFault(
+                LoopStage::kNormalizeInput,
+                FaultPolicyContext{
+                    .fault_class = FaultClass::kEvent,
+                    .contract_violation = true,
+                },
+                error);
         }
     });
 
@@ -69,34 +102,67 @@ bool PlatformHostRuntime::Configure(const LoopPolicy& policy, WindowSpec primary
 
     loop_runner_.SetStageHandler(LoopStage::kPreRender, [this]() {
         if (!window_host_) {
-            SetErrorForStage(LoopStage::kPreRender, "window host is not set");
+            HandleStageFault(
+                LoopStage::kPreRender,
+                FaultPolicyContext{
+                    .fault_class = FaultClass::kRender,
+                    .contract_violation = true,
+                },
+                "window host is not set");
             return;
         }
 
         if (!window_host_->PreRender()) {
-            SetErrorForStage(LoopStage::kPreRender, "window host pre-render failed");
+            HandleStageFault(
+                LoopStage::kPreRender,
+                FaultPolicyContext{
+                    .fault_class = FaultClass::kRender,
+                },
+                "window host pre-render failed");
         }
     });
 
     loop_runner_.SetStageHandler(LoopStage::kRender, [this]() {
         if (!window_host_) {
-            SetErrorForStage(LoopStage::kRender, "window host is not set");
+            HandleStageFault(
+                LoopStage::kRender,
+                FaultPolicyContext{
+                    .fault_class = FaultClass::kRender,
+                    .contract_violation = true,
+                },
+                "window host is not set");
             return;
         }
 
         if (!window_host_->Render()) {
-            SetErrorForStage(LoopStage::kRender, "window host render failed");
+            HandleStageFault(
+                LoopStage::kRender,
+                FaultPolicyContext{
+                    .fault_class = FaultClass::kRender,
+                },
+                "window host render failed");
         }
     });
 
     loop_runner_.SetStageHandler(LoopStage::kPostRender, [this]() {
         if (!window_host_) {
-            SetErrorForStage(LoopStage::kPostRender, "window host is not set");
+            HandleStageFault(
+                LoopStage::kPostRender,
+                FaultPolicyContext{
+                    .fault_class = FaultClass::kRender,
+                    .contract_violation = true,
+                },
+                "window host is not set");
             return;
         }
 
         if (!window_host_->PostRender()) {
-            SetErrorForStage(LoopStage::kPostRender, "window host post-render failed");
+            HandleStageFault(
+                LoopStage::kPostRender,
+                FaultPolicyContext{
+                    .fault_class = FaultClass::kRender,
+                },
+                "window host post-render failed");
         }
     });
 
@@ -218,7 +284,26 @@ bool PlatformHostRuntime::HasActiveRenderStages() const {
         std::find(active_stages.begin(), active_stages.end(), LoopStage::kPostRender) != active_stages.end();
 }
 
-void PlatformHostRuntime::SetErrorForStage(LoopStage stage, const std::string& message) {
+void PlatformHostRuntime::HandleStageFault(
+    LoopStage stage,
+    FaultPolicyContext context,
+    const std::string& message) {
+    const auto decision = fault_policy_.Evaluate(context);
+
+    if (decision.disposition == FaultDisposition::kDegrade) {
+        if (!last_error_.empty()) {
+            return;
+        }
+
+        last_error_ = "loop stage ";
+        last_error_ += LoopStageName(stage);
+        last_error_ += " degraded: ";
+        last_error_ += decision.reason;
+        last_error_ += "; detail: ";
+        last_error_ += message;
+        return;
+    }
+
     frame_failed_ = true;
     if (!last_error_.empty()) {
         return;
@@ -228,6 +313,8 @@ void PlatformHostRuntime::SetErrorForStage(LoopStage stage, const std::string& m
     last_error_ += LoopStageName(stage);
     last_error_ += " failed: ";
     last_error_ += message;
+    last_error_ += "; policy: ";
+    last_error_ += decision.reason;
 }
 
 } // namespace framekit::runtime

--- a/tests/test_platform_host_runtime.cpp
+++ b/tests/test_platform_host_runtime.cpp
@@ -191,7 +191,7 @@ void TestTickFailsOnPlatformPumpFailure() {
     REQUIRE(runtime.Stop());
 }
 
-void TestTickFailsOnWindowRenderFailure() {
+void TestTickRenderFailureDegradesThenEscalates() {
     framekit::runtime::LoopPolicy policy;
     policy.profile = framekit::runtime::LoopProfile::kGui;
     policy.rendering_enabled = true;
@@ -206,8 +206,37 @@ void TestTickFailsOnWindowRenderFailure() {
 
     REQUIRE(runtime.Configure(policy));
     REQUIRE(runtime.Start());
+    REQUIRE(runtime.Tick());
+    REQUIRE(runtime.LastError().find("Render") != std::string::npos);
+    REQUIRE(runtime.LastError().find("degraded") != std::string::npos);
+
+    REQUIRE(runtime.Tick());
+    REQUIRE(runtime.LastError().find("degraded") != std::string::npos);
+
     REQUIRE(!runtime.Tick());
     REQUIRE(runtime.LastError().find("Render") != std::string::npos);
+    REQUIRE(runtime.LastError().find("escalating to fail-fast") != std::string::npos);
+    REQUIRE(runtime.LastError().find("failed") != std::string::npos);
+    REQUIRE(runtime.Stop());
+}
+
+void TestDeterministicHostRenderFailureFailsFastImmediately() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kDeterministicHost;
+    policy.rendering_enabled = true;
+
+    auto platform = std::make_shared<FakePlatformHost>();
+    auto window = std::make_shared<FakeWindowHost>();
+    window->render_result = false;
+
+    framekit::runtime::PlatformHostRuntime runtime;
+    runtime.SetPlatformHost(platform);
+    runtime.SetWindowHost(window);
+
+    REQUIRE(runtime.Configure(policy));
+    REQUIRE(runtime.Start());
+    REQUIRE(!runtime.Tick());
+    REQUIRE(runtime.LastError().find("deterministic host profile") != std::string::npos);
     REQUIRE(runtime.Stop());
 }
 
@@ -219,6 +248,7 @@ int main() {
     TestStartFailsWithoutPlatformHost();
     TestStartFailsWhenRenderStagesActiveWithoutWindowHost();
     TestTickFailsOnPlatformPumpFailure();
-    TestTickFailsOnWindowRenderFailure();
+    TestTickRenderFailureDegradesThenEscalates();
+    TestDeterministicHostRenderFailureFailsFastImmediately();
     return 0;
 }


### PR DESCRIPTION
Summary:\n- wire fault-policy decisions into platform stage failure handling\n- allow bounded render degrade before escalation to fail-fast\n- enforce deterministic host immediate fail-fast behavior in platform stage faults\n- update platform runtime tests for degrade and escalation outcomes\n\nValidation:\n- cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON\n- cmake --build build -j4\n- ctest --test-dir build --output-on-failure\n\nCloses #88