### PR TITLE
feat(loop): enforce timing and overrun execution semantics (#92)

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -9,7 +9,7 @@ Current baseline includes:
 - lifecycle state machine and kernel runtime start/stop orchestration
 - loop profile and execution-policy validation contracts
 - profile-aware fault-policy runtime with bounded degrade budgets and fail-fast escalation integrated into platform stage-failure handling
-- loop stage graph runner with deterministic baseline-stage execution order
+- loop stage graph runner with deterministic baseline-stage execution order and fixed-delta overrun semantics (slip, bounded catch-up, drop-noncritical, fail-fast)
 - platform/window host baseline runtime integrated with stage-driven event pump and render hooks
 - input normalization and window-aware immediate routing runtime integrated with loop stages
 - service context freeze/lookup semantics and teardown ordering

--- a/include/framekit/loop/policy.hpp
+++ b/include/framekit/loop/policy.hpp
@@ -37,6 +37,7 @@ struct LoopPolicy {
     TimingMode timing_mode = TimingMode::kVariableDelta;
     OverrunMode overrun_mode = OverrunMode::kSlip;
     ThreadingMode threading_mode = ThreadingMode::kSingleThreaded;
+    std::uint64_t fixed_delta_ns = 16666667;
     std::uint32_t max_catch_up_steps = 0;
     bool rendering_enabled = true;
     std::vector<std::string> disabled_optional_stages;

--- a/include/framekit/loop/stage_graph.hpp
+++ b/include/framekit/loop/stage_graph.hpp
@@ -38,12 +38,15 @@ public:
     void SetStageHandler(LoopStage stage, StageHandler handler);
     void ClearStageHandlers();
 
-    bool ExecuteFrame();
+    bool ExecuteFrame(std::uint64_t elapsed_ns = 0);
 
     bool IsConfigured() const;
     const LoopPolicy& Policy() const;
     const std::vector<LoopStage>& ActiveStages() const;
     const std::vector<LoopStage>& LastExecutedStages() const;
+    std::uint32_t LastUpdateStepCount() const;
+    std::uint32_t LastDroppedUpdateStepCount() const;
+    bool LastFrameDroppedNonCriticalStages() const;
     const std::string& LastError() const;
 
 private:
@@ -57,6 +60,10 @@ private:
     std::unordered_map<LoopStage, StageHandler, LoopStageHash> handlers_;
     std::vector<LoopStage> active_stages_;
     std::vector<LoopStage> last_executed_stages_;
+    std::uint32_t last_update_step_count_ = 1;
+    std::uint32_t last_dropped_update_step_count_ = 0;
+    bool last_frame_dropped_non_critical_stages_ = false;
+    std::uint64_t fixed_delta_accumulator_ns_ = 0;
     std::string last_error_;
     bool configured_ = false;
 };

--- a/include/framekit/platform/host_runtime.hpp
+++ b/include/framekit/platform/host_runtime.hpp
@@ -5,6 +5,7 @@
 #include "framekit/loop/policy.hpp"
 #include "framekit/loop/stage_graph.hpp"
 
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -75,6 +76,8 @@ private:
     bool running_ = false;
     bool window_created_ = false;
     bool frame_failed_ = false;
+    bool has_last_tick_timestamp_ = false;
+    std::chrono::steady_clock::time_point last_tick_timestamp_{};
     std::string last_error_;
 };
 

--- a/src/loop_policy.cpp
+++ b/src/loop_policy.cpp
@@ -60,6 +60,10 @@ LoopPolicyValidation Invalid(std::string reason) {
 } // namespace
 
 LoopPolicyValidation ValidateLoopPolicy(const LoopPolicy& policy) {
+    if (policy.timing_mode == TimingMode::kFixedDelta && policy.fixed_delta_ns == 0) {
+        return Invalid("fixed_delta timing requires fixed_delta_ns > 0");
+    }
+
     if (policy.timing_mode == TimingMode::kFixedDelta &&
         policy.overrun_mode == OverrunMode::kCatchUpBounded &&
         policy.max_catch_up_steps == 0) {

--- a/src/loop_stage_graph.cpp
+++ b/src/loop_stage_graph.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <limits>
 #include <set>
 
 namespace framekit::runtime {
@@ -22,6 +23,25 @@ const std::array<std::pair<LoopStage, const char*>, 12> kStageNameTable = {{
     {LoopStage::kPostRender, "PostRender"},
     {LoopStage::kEndFrame, "EndFrame"},
 }};
+
+bool IsRenderStage(LoopStage stage) {
+    return stage == LoopStage::kPreRender ||
+        stage == LoopStage::kRender ||
+        stage == LoopStage::kPostRender;
+}
+
+bool IsOptionalForProfile(LoopProfile profile, LoopStage stage) {
+    if (!IsRenderStage(stage)) {
+        return false;
+    }
+
+    return profile == LoopProfile::kHeadless ||
+        profile == LoopProfile::kDeterministicHost;
+}
+
+bool ContainsStage(const std::vector<LoopStage>& stages, LoopStage stage) {
+    return std::find(stages.begin(), stages.end(), stage) != stages.end();
+}
 
 } // namespace
 
@@ -108,6 +128,10 @@ bool LoopStageGraphRunner::Configure(const LoopPolicy& policy) {
     configured_ = true;
     last_error_.clear();
     last_executed_stages_.clear();
+    last_update_step_count_ = 1;
+    last_dropped_update_step_count_ = 0;
+    last_frame_dropped_non_critical_stages_ = false;
+    fixed_delta_accumulator_ns_ = 0;
     return true;
 }
 
@@ -124,22 +148,107 @@ void LoopStageGraphRunner::ClearStageHandlers() {
     handlers_.clear();
 }
 
-bool LoopStageGraphRunner::ExecuteFrame() {
+bool LoopStageGraphRunner::ExecuteFrame(std::uint64_t elapsed_ns) {
     if (!configured_) {
         last_error_ = "loop stage graph runner is not configured";
         return false;
     }
 
-    last_executed_stages_.clear();
-    last_executed_stages_.reserve(active_stages_.size());
+    last_error_.clear();
+    last_update_step_count_ = 1;
+    last_dropped_update_step_count_ = 0;
+    last_frame_dropped_non_critical_stages_ = false;
+    bool should_drop_non_critical_stages = false;
 
-    for (const auto stage : active_stages_) {
+    if (policy_.timing_mode == TimingMode::kFixedDelta) {
+        if (policy_.fixed_delta_ns == 0) {
+            last_error_ = "fixed-delta timing requires fixed_delta_ns > 0";
+            return false;
+        }
+
+        const std::uint64_t observed_elapsed_ns = elapsed_ns == 0 ? policy_.fixed_delta_ns : elapsed_ns;
+        fixed_delta_accumulator_ns_ += observed_elapsed_ns;
+
+        std::uint64_t requested_steps_u64 = fixed_delta_accumulator_ns_ / policy_.fixed_delta_ns;
+        if (requested_steps_u64 == 0) {
+            requested_steps_u64 = 1;
+        }
+
+        requested_steps_u64 = std::min(
+            requested_steps_u64,
+            static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()));
+
+        const auto requested_steps = static_cast<std::uint32_t>(requested_steps_u64);
+        if (requested_steps > 1) {
+            switch (policy_.overrun_mode) {
+            case OverrunMode::kSlip:
+                last_update_step_count_ = 1;
+                last_dropped_update_step_count_ = requested_steps - 1;
+                break;
+            case OverrunMode::kCatchUpBounded: {
+                const auto max_allowed_steps = static_cast<std::uint32_t>(1 + policy_.max_catch_up_steps);
+                last_update_step_count_ = std::min(requested_steps, max_allowed_steps);
+                last_dropped_update_step_count_ = requested_steps - last_update_step_count_;
+                break;
+            }
+            case OverrunMode::kDropNonCritical:
+                last_update_step_count_ = 1;
+                last_dropped_update_step_count_ = requested_steps - 1;
+                should_drop_non_critical_stages = true;
+                break;
+            case OverrunMode::kFailFast:
+                last_error_ = "timing overrun: fixed-delta frame exceeded budget in fail-fast mode";
+                return false;
+            }
+        }
+
+        if (fixed_delta_accumulator_ns_ >= policy_.fixed_delta_ns) {
+            fixed_delta_accumulator_ns_ %= policy_.fixed_delta_ns;
+        }
+    } else {
+        fixed_delta_accumulator_ns_ = 0;
+    }
+
+    last_executed_stages_.clear();
+    last_executed_stages_.reserve(
+        active_stages_.size() + static_cast<std::size_t>(last_update_step_count_) * 2);
+
+    const bool has_update = ContainsStage(active_stages_, LoopStage::kUpdate);
+    const bool has_post_update = ContainsStage(active_stages_, LoopStage::kPostUpdate);
+
+    auto execute_stage = [this](LoopStage stage) {
         last_executed_stages_.push_back(stage);
 
         const auto handler_it = handlers_.find(stage);
         if (handler_it != handlers_.end() && handler_it->second) {
             handler_it->second();
         }
+    };
+
+    for (const auto stage : active_stages_) {
+        if (stage == LoopStage::kUpdate || stage == LoopStage::kPostUpdate) {
+            continue;
+        }
+
+        if (stage == LoopStage::kPreUpdate) {
+            for (std::uint32_t step = 0; step < last_update_step_count_; ++step) {
+                execute_stage(LoopStage::kPreUpdate);
+                if (has_update) {
+                    execute_stage(LoopStage::kUpdate);
+                }
+                if (has_post_update) {
+                    execute_stage(LoopStage::kPostUpdate);
+                }
+            }
+            continue;
+        }
+
+        if (should_drop_non_critical_stages && IsOptionalForProfile(policy_.profile, stage)) {
+            last_frame_dropped_non_critical_stages_ = true;
+            continue;
+        }
+
+        execute_stage(stage);
     }
 
     return true;
@@ -159,6 +268,18 @@ const std::vector<LoopStage>& LoopStageGraphRunner::ActiveStages() const {
 
 const std::vector<LoopStage>& LoopStageGraphRunner::LastExecutedStages() const {
     return last_executed_stages_;
+}
+
+std::uint32_t LoopStageGraphRunner::LastUpdateStepCount() const {
+    return last_update_step_count_;
+}
+
+std::uint32_t LoopStageGraphRunner::LastDroppedUpdateStepCount() const {
+    return last_dropped_update_step_count_;
+}
+
+bool LoopStageGraphRunner::LastFrameDroppedNonCriticalStages() const {
+    return last_frame_dropped_non_critical_stages_;
 }
 
 const std::string& LoopStageGraphRunner::LastError() const {

--- a/src/platform_host_runtime.cpp
+++ b/src/platform_host_runtime.cpp
@@ -208,6 +208,8 @@ bool PlatformHostRuntime::Start() {
     }
 
     running_ = true;
+    has_last_tick_timestamp_ = true;
+    last_tick_timestamp_ = std::chrono::steady_clock::now();
     last_error_.clear();
     return true;
 }
@@ -221,7 +223,18 @@ bool PlatformHostRuntime::Tick() {
     frame_failed_ = false;
     last_error_.clear();
 
-    if (!loop_runner_.ExecuteFrame()) {
+    const auto now = std::chrono::steady_clock::now();
+    std::uint64_t elapsed_ns = 0;
+    if (has_last_tick_timestamp_) {
+        const auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            now - last_tick_timestamp_);
+        elapsed_ns = static_cast<std::uint64_t>(elapsed.count());
+    } else {
+        has_last_tick_timestamp_ = true;
+    }
+    last_tick_timestamp_ = now;
+
+    if (!loop_runner_.ExecuteFrame(elapsed_ns)) {
         last_error_ = loop_runner_.LastError();
         return false;
     }
@@ -254,6 +267,7 @@ bool PlatformHostRuntime::Stop() {
     running_ = false;
     window_created_ = false;
     frame_failed_ = false;
+    has_last_tick_timestamp_ = false;
     return ok;
 }
 

--- a/tests/test_loop_stage_graph.cpp
+++ b/tests/test_loop_stage_graph.cpp
@@ -29,6 +29,12 @@ std::vector<std::string> StageNames(const std::vector<framekit::runtime::LoopSta
     return names;
 }
 
+std::size_t CountStage(
+    const std::vector<framekit::runtime::LoopStage>& stages,
+    framekit::runtime::LoopStage target) {
+    return static_cast<std::size_t>(std::count(stages.begin(), stages.end(), target));
+}
+
 void TestBaselineGuiExecutionOrder() {
     framekit::runtime::LoopPolicy policy;
     policy.profile = framekit::runtime::LoopProfile::kGui;
@@ -97,6 +103,117 @@ void TestUnknownDisabledStageRejected() {
     REQUIRE(!runner.LastError().empty());
 }
 
+void TestFixedDeltaCatchUpBoundedRunsExtraUpdateSteps() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kHybrid;
+    policy.rendering_enabled = true;
+    policy.timing_mode = framekit::runtime::TimingMode::kFixedDelta;
+    policy.overrun_mode = framekit::runtime::OverrunMode::kCatchUpBounded;
+    policy.fixed_delta_ns = 1000000;
+    policy.max_catch_up_steps = 2;
+
+    framekit::runtime::LoopStageGraphRunner runner;
+    REQUIRE(runner.Configure(policy));
+    REQUIRE(runner.ExecuteFrame(policy.fixed_delta_ns * 3));
+
+    REQUIRE(runner.LastUpdateStepCount() == 3);
+    REQUIRE(runner.LastDroppedUpdateStepCount() == 0);
+    REQUIRE(!runner.LastFrameDroppedNonCriticalStages());
+
+    const auto& executed = runner.LastExecutedStages();
+    REQUIRE(CountStage(executed, framekit::runtime::LoopStage::kPreUpdate) == 3);
+    REQUIRE(CountStage(executed, framekit::runtime::LoopStage::kUpdate) == 3);
+    REQUIRE(CountStage(executed, framekit::runtime::LoopStage::kPostUpdate) == 3);
+    REQUIRE(CountStage(executed, framekit::runtime::LoopStage::kRender) == 1);
+}
+
+void TestFixedDeltaCatchUpBoundedDropsBeyondBudget() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kHybrid;
+    policy.rendering_enabled = true;
+    policy.timing_mode = framekit::runtime::TimingMode::kFixedDelta;
+    policy.overrun_mode = framekit::runtime::OverrunMode::kCatchUpBounded;
+    policy.fixed_delta_ns = 1000000;
+    policy.max_catch_up_steps = 1;
+
+    framekit::runtime::LoopStageGraphRunner runner;
+    REQUIRE(runner.Configure(policy));
+    REQUIRE(runner.ExecuteFrame(policy.fixed_delta_ns * 4));
+
+    REQUIRE(runner.LastUpdateStepCount() == 2);
+    REQUIRE(runner.LastDroppedUpdateStepCount() == 2);
+}
+
+void TestFixedDeltaFailFastRejectsOverrun() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kHybrid;
+    policy.rendering_enabled = true;
+    policy.timing_mode = framekit::runtime::TimingMode::kFixedDelta;
+    policy.overrun_mode = framekit::runtime::OverrunMode::kFailFast;
+    policy.fixed_delta_ns = 1000000;
+
+    framekit::runtime::LoopStageGraphRunner runner;
+    REQUIRE(runner.Configure(policy));
+    REQUIRE(!runner.ExecuteFrame(policy.fixed_delta_ns * 2));
+    REQUIRE(runner.LastError().find("timing overrun") != std::string::npos);
+}
+
+void TestDropNonCriticalDropsOptionalRenderStagesForDeterministicHost() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kDeterministicHost;
+    policy.rendering_enabled = true;
+    policy.timing_mode = framekit::runtime::TimingMode::kFixedDelta;
+    policy.overrun_mode = framekit::runtime::OverrunMode::kDropNonCritical;
+    policy.fixed_delta_ns = 1000000;
+
+    framekit::runtime::LoopStageGraphRunner runner;
+    REQUIRE(runner.Configure(policy));
+
+    int render_calls = 0;
+    runner.SetStageHandler(framekit::runtime::LoopStage::kPreRender, [&render_calls]() {
+        render_calls += 1;
+    });
+    runner.SetStageHandler(framekit::runtime::LoopStage::kRender, [&render_calls]() {
+        render_calls += 1;
+    });
+    runner.SetStageHandler(framekit::runtime::LoopStage::kPostRender, [&render_calls]() {
+        render_calls += 1;
+    });
+
+    REQUIRE(runner.ExecuteFrame(policy.fixed_delta_ns * 2));
+    REQUIRE(runner.LastFrameDroppedNonCriticalStages());
+    REQUIRE(runner.LastUpdateStepCount() == 1);
+    REQUIRE(runner.LastDroppedUpdateStepCount() == 1);
+    REQUIRE(render_calls == 0);
+
+    const auto executed_names = StageNames(runner.LastExecutedStages());
+    REQUIRE(std::find(executed_names.begin(), executed_names.end(), "PreRender") == executed_names.end());
+    REQUIRE(std::find(executed_names.begin(), executed_names.end(), "Render") == executed_names.end());
+    REQUIRE(std::find(executed_names.begin(), executed_names.end(), "PostRender") == executed_names.end());
+}
+
+void TestDropNonCriticalDoesNotDropRequiredRenderStagesInGuiProfile() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kGui;
+    policy.rendering_enabled = true;
+    policy.timing_mode = framekit::runtime::TimingMode::kFixedDelta;
+    policy.overrun_mode = framekit::runtime::OverrunMode::kDropNonCritical;
+    policy.fixed_delta_ns = 1000000;
+
+    framekit::runtime::LoopStageGraphRunner runner;
+    REQUIRE(runner.Configure(policy));
+
+    int render_calls = 0;
+    runner.SetStageHandler(framekit::runtime::LoopStage::kRender, [&render_calls]() {
+        render_calls += 1;
+    });
+
+    REQUIRE(runner.ExecuteFrame(policy.fixed_delta_ns * 2));
+    REQUIRE(!runner.LastFrameDroppedNonCriticalStages());
+    REQUIRE(runner.LastDroppedUpdateStepCount() == 1);
+    REQUIRE(render_calls == 1);
+}
+
 } // namespace
 
 int main() {
@@ -104,5 +221,10 @@ int main() {
     TestHeadlessRenderStagesOmitted();
     TestInvalidPolicyRejected();
     TestUnknownDisabledStageRejected();
+    TestFixedDeltaCatchUpBoundedRunsExtraUpdateSteps();
+    TestFixedDeltaCatchUpBoundedDropsBeyondBudget();
+    TestFixedDeltaFailFastRejectsOverrun();
+    TestDropNonCriticalDropsOptionalRenderStagesForDeterministicHost();
+    TestDropNonCriticalDoesNotDropRequiredRenderStagesInGuiProfile();
     return 0;
 }

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -57,6 +57,12 @@ void TestLoopPolicyValidation() {
     const auto fixed_result = framekit::runtime::ValidateLoopPolicy(fixed_catch_up);
     REQUIRE(!fixed_result.valid);
 
+    framekit::runtime::LoopPolicy invalid_fixed_quantum;
+    invalid_fixed_quantum.timing_mode = framekit::runtime::TimingMode::kFixedDelta;
+    invalid_fixed_quantum.fixed_delta_ns = 0;
+    const auto invalid_fixed_quantum_result = framekit::runtime::ValidateLoopPolicy(invalid_fixed_quantum);
+    REQUIRE(!invalid_fixed_quantum_result.valid);
+
     framekit::runtime::LoopPolicy headless;
     headless.profile = framekit::runtime::LoopProfile::kHeadless;
     headless.rendering_enabled = false;


### PR DESCRIPTION
Summary:\n- enforce fixed-delta timing overrun semantics in loop stage execution (slip, catch-up bounded, drop-noncritical, fail-fast)\n- repeat update wrappers for bounded catch-up and expose deterministic frame execution metadata\n- pass elapsed tick timing from platform host runtime into loop runner\n- add policy validation guard for invalid fixed_delta_ns and expand contract tests\n\nValidation:\n- cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON\n- cmake --build build -j4\n- ctest --test-dir build --output-on-failure\n\nCloses #92