### PR TITLE
feat(kernel): orchestrate module lifecycle over DAG order (#94)

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -13,7 +13,7 @@ Current baseline includes:
 - platform/window host baseline runtime integrated with stage-driven event pump and render hooks
 - input normalization and window-aware immediate routing runtime integrated with loop stages
 - service context freeze/lookup semantics and teardown ordering
-- module dependency DAG validation with deterministic startup/shutdown ordering
+- module dependency DAG validation with deterministic initialize/start orchestration and reverse-order stop/teardown
 - event bus immediate/deferred dispatch baseline with consume and priority semantics
 - selective-linking guidance for optional module usage
 

--- a/include/framekit/kernel/runtime.hpp
+++ b/include/framekit/kernel/runtime.hpp
@@ -3,6 +3,7 @@
 #include "framekit/service/bootstrap.hpp"
 #include "framekit/event/bus.hpp"
 #include "framekit/lifecycle/state_machine.hpp"
+#include "framekit/module/graph.hpp"
 #include "framekit/service/context.hpp"
 
 #include <cstddef>
@@ -19,17 +20,27 @@ enum class ShutdownDeferredEventPolicy : std::uint8_t {
     kDiscardWithDiagnostics = 2,
 };
 
+enum class ModuleLifecyclePhase : std::uint8_t {
+    kInitialize = 0,
+    kStart = 1,
+    kStop = 2,
+    kTeardown = 3,
+};
+
 class KernelRuntime {
 public:
     using BootstrapStep = std::function<bool(ServiceContext&)>;
     using InitializeStep = std::function<bool(ServiceContext&)>;
     using ModuleStopHandler = std::function<bool(const std::string& module_id)>;
+    using ModuleLifecycleHandler = std::function<bool(const std::string& module_id, ModuleLifecyclePhase phase)>;
     using PlatformTeardownStep = std::function<bool()>;
     using DiagnosticsFlushStep = std::function<void()>;
 
     void SetBootstrapStep(BootstrapStep step);
     void SetInitializeStep(InitializeStep step);
     void SetModuleStopHandler(ModuleStopHandler handler);
+    bool ConfigureModules(std::vector<ModuleSpec> modules);
+    void SetModuleLifecycleHandler(ModuleLifecycleHandler handler);
     void SetDiagnosticsFlushStep(DiagnosticsFlushStep step);
     void SetEventBus(std::shared_ptr<EventBus> event_bus);
 
@@ -49,12 +60,16 @@ public:
     ServiceContext& Services();
     const ServiceContext& Services() const;
 
+    const std::vector<std::string>& LastModuleStartupOrder() const;
     const std::vector<std::string>& LastModuleShutdownOrder() const;
+    const std::vector<std::string>& LastModuleTeardownOrder() const;
     const std::vector<std::string>& LastPlatformTeardownOrder() const;
+    const ModuleGraphValidationResult& LastModuleGraphValidation() const;
     const std::string& LastFaultReason() const;
 
 private:
     void Fault(std::string reason);
+    bool ExecuteModuleStartupSequence();
     bool ExecuteShutdownSequence();
 
     LifecycleStateMachine lifecycle_;
@@ -62,6 +77,7 @@ private:
     BootstrapStep bootstrap_step_;
     InitializeStep initialize_step_;
     ModuleStopHandler module_stop_handler_;
+    ModuleLifecycleHandler module_lifecycle_handler_;
     DiagnosticsFlushStep diagnostics_flush_step_;
     std::shared_ptr<EventBus> event_bus_;
 
@@ -70,7 +86,12 @@ private:
     std::size_t deferred_event_bounded_limit_ = 0;
 
     std::vector<std::string> started_modules_;
+    std::vector<std::string> configured_module_startup_order_;
+    std::vector<std::string> last_module_startup_order_;
     std::vector<std::string> last_module_shutdown_order_;
+    std::vector<std::string> last_module_teardown_order_;
+    bool modules_configured_ = false;
+    ModuleGraphValidationResult module_graph_validation_;
 
     struct NamedTeardownStep {
         std::string name;

--- a/src/kernel_runtime.cpp
+++ b/src/kernel_runtime.cpp
@@ -16,6 +16,23 @@ void KernelRuntime::SetModuleStopHandler(ModuleStopHandler handler) {
     module_stop_handler_ = std::move(handler);
 }
 
+bool KernelRuntime::ConfigureModules(std::vector<ModuleSpec> modules) {
+    modules_configured_ = true;
+    module_graph_validation_ = ValidateModuleGraph(modules);
+    configured_module_startup_order_.clear();
+
+    if (!module_graph_validation_.valid) {
+        return false;
+    }
+
+    configured_module_startup_order_ = module_graph_validation_.startup_order;
+    return true;
+}
+
+void KernelRuntime::SetModuleLifecycleHandler(ModuleLifecycleHandler handler) {
+    module_lifecycle_handler_ = std::move(handler);
+}
+
 void KernelRuntime::SetDiagnosticsFlushStep(DiagnosticsFlushStep step) {
     diagnostics_flush_step_ = std::move(step);
 }
@@ -40,6 +57,7 @@ void KernelRuntime::AddPlatformTeardownStep(std::string name, PlatformTeardownSt
 
 void KernelRuntime::RecordStartedModules(std::vector<std::string> startup_order) {
     started_modules_ = std::move(startup_order);
+    last_module_startup_order_ = started_modules_;
 }
 
 bool KernelRuntime::Start() {
@@ -69,6 +87,11 @@ bool KernelRuntime::Start() {
 
     if (!services_.Freeze()) {
         Fault("service context freeze failed");
+        return false;
+    }
+
+    if (!ExecuteModuleStartupSequence()) {
+        Fault(last_fault_reason_.empty() ? "module startup sequence failed" : last_fault_reason_);
         return false;
     }
 
@@ -122,12 +145,24 @@ const ServiceContext& KernelRuntime::Services() const {
     return services_;
 }
 
+const std::vector<std::string>& KernelRuntime::LastModuleStartupOrder() const {
+    return last_module_startup_order_;
+}
+
 const std::vector<std::string>& KernelRuntime::LastModuleShutdownOrder() const {
     return last_module_shutdown_order_;
 }
 
+const std::vector<std::string>& KernelRuntime::LastModuleTeardownOrder() const {
+    return last_module_teardown_order_;
+}
+
 const std::vector<std::string>& KernelRuntime::LastPlatformTeardownOrder() const {
     return last_platform_teardown_order_;
+}
+
+const ModuleGraphValidationResult& KernelRuntime::LastModuleGraphValidation() const {
+    return module_graph_validation_;
 }
 
 const std::string& KernelRuntime::LastFaultReason() const {
@@ -141,17 +176,74 @@ void KernelRuntime::Fault(std::string reason) {
     }
 }
 
+bool KernelRuntime::ExecuteModuleStartupSequence() {
+    last_module_startup_order_.clear();
+
+    if (modules_configured_) {
+        if (!module_graph_validation_.valid) {
+            if (!module_graph_validation_.errors.empty()) {
+                last_fault_reason_ = module_graph_validation_.errors.front().message;
+            } else {
+                last_fault_reason_ = "module graph validation failed";
+            }
+            return false;
+        }
+
+        started_modules_.clear();
+        if (!module_lifecycle_handler_) {
+            started_modules_ = configured_module_startup_order_;
+            last_module_startup_order_ = started_modules_;
+            return true;
+        }
+
+        for (const auto& module_id : configured_module_startup_order_) {
+            if (!module_lifecycle_handler_(module_id, ModuleLifecyclePhase::kInitialize)) {
+                last_fault_reason_ = "module initialize failed: " + module_id;
+                return false;
+            }
+
+            if (!module_lifecycle_handler_(module_id, ModuleLifecyclePhase::kStart)) {
+                last_fault_reason_ = "module start failed: " + module_id;
+                return false;
+            }
+
+            started_modules_.push_back(module_id);
+            last_module_startup_order_.push_back(module_id);
+        }
+
+        return true;
+    }
+
+    if (!started_modules_.empty()) {
+        last_module_startup_order_ = started_modules_;
+    }
+
+    return true;
+}
+
 bool KernelRuntime::ExecuteShutdownSequence() {
     bool had_failure = false;
 
     last_module_shutdown_order_.clear();
+    last_module_teardown_order_.clear();
     for (auto it = started_modules_.rbegin(); it != started_modules_.rend(); ++it) {
         last_module_shutdown_order_.push_back(*it);
 
-        if (module_stop_handler_ && !module_stop_handler_(*it)) {
+        if (module_lifecycle_handler_) {
+            if (!module_lifecycle_handler_(*it, ModuleLifecyclePhase::kStop)) {
+                had_failure = true;
+            }
+
+            last_module_teardown_order_.push_back(*it);
+            if (!module_lifecycle_handler_(*it, ModuleLifecyclePhase::kTeardown)) {
+                had_failure = true;
+            }
+        } else if (module_stop_handler_ && !module_stop_handler_(*it)) {
             had_failure = true;
         }
     }
+
+    started_modules_.clear();
 
     if (event_bus_) {
         switch (deferred_event_policy_) {

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -30,6 +30,21 @@ struct AlternateService {
     std::string name;
 };
 
+const char* ModuleLifecyclePhaseName(framekit::runtime::ModuleLifecyclePhase phase) {
+    switch (phase) {
+        case framekit::runtime::ModuleLifecyclePhase::kInitialize:
+            return "initialize";
+        case framekit::runtime::ModuleLifecyclePhase::kStart:
+            return "start";
+        case framekit::runtime::ModuleLifecyclePhase::kStop:
+            return "stop";
+        case framekit::runtime::ModuleLifecyclePhase::kTeardown:
+            return "teardown";
+    }
+
+    return "unknown";
+}
+
 void TestLifecycleStateMachine() {
     framekit::runtime::LifecycleStateMachine machine;
 
@@ -299,6 +314,9 @@ void TestKernelRuntime() {
     REQUIRE(runtime.Start());
     REQUIRE(runtime.IsRunning());
     REQUIRE(runtime.State() == framekit::runtime::LifecycleState::kRunning);
+    REQUIRE(runtime.LastModuleStartupOrder().size() == 2);
+    REQUIRE(runtime.LastModuleStartupOrder()[0] == "module-core");
+    REQUIRE(runtime.LastModuleStartupOrder()[1] == "module-app");
     REQUIRE(runtime.Services().Phase() == framekit::runtime::ServiceContextPhase::kFrozen);
     REQUIRE(!runtime.Services().Register(std::make_shared<framekit::runtime::DiagnosticsService>(), "late"));
 
@@ -332,6 +350,103 @@ void TestKernelRuntime() {
     REQUIRE(faulty.State() == framekit::runtime::LifecycleState::kStopped);
 }
 
+void TestKernelRuntimeModuleLifecycleOrchestration() {
+    const std::vector<framekit::runtime::ModuleSpec> modules = {
+        framekit::runtime::ModuleSpec{
+            .id = "frontend",
+            .required_dependencies = {"backend"},
+            .optional_dependencies = {},
+        },
+        framekit::runtime::ModuleSpec{
+            .id = "backend",
+            .required_dependencies = {},
+            .optional_dependencies = {},
+        },
+    };
+
+    framekit::runtime::KernelRuntime runtime;
+    REQUIRE(runtime.ConfigureModules(modules));
+    REQUIRE(runtime.LastModuleGraphValidation().valid);
+    REQUIRE(runtime.LastModuleGraphValidation().startup_order.size() == 2);
+
+    std::vector<std::string> lifecycle_calls;
+    runtime.SetModuleLifecycleHandler([&lifecycle_calls](
+                                         const std::string& module_id,
+                                         framekit::runtime::ModuleLifecyclePhase phase) {
+        lifecycle_calls.push_back(module_id + ":" + ModuleLifecyclePhaseName(phase));
+        return true;
+    });
+
+    REQUIRE(runtime.Start());
+    REQUIRE(runtime.State() == framekit::runtime::LifecycleState::kRunning);
+    REQUIRE(runtime.LastModuleStartupOrder().size() == 2);
+    REQUIRE(runtime.LastModuleStartupOrder()[0] == "backend");
+    REQUIRE(runtime.LastModuleStartupOrder()[1] == "frontend");
+
+    REQUIRE(runtime.Stop());
+    REQUIRE(runtime.LastModuleShutdownOrder().size() == 2);
+    REQUIRE(runtime.LastModuleShutdownOrder()[0] == "frontend");
+    REQUIRE(runtime.LastModuleShutdownOrder()[1] == "backend");
+    REQUIRE(runtime.LastModuleTeardownOrder().size() == 2);
+    REQUIRE(runtime.LastModuleTeardownOrder()[0] == "frontend");
+    REQUIRE(runtime.LastModuleTeardownOrder()[1] == "backend");
+
+    const std::vector<std::string> expected_calls = {
+        "backend:initialize",
+        "backend:start",
+        "frontend:initialize",
+        "frontend:start",
+        "frontend:stop",
+        "frontend:teardown",
+        "backend:stop",
+        "backend:teardown",
+    };
+    REQUIRE(lifecycle_calls == expected_calls);
+
+    framekit::runtime::KernelRuntime startup_failure;
+    REQUIRE(startup_failure.ConfigureModules(modules));
+
+    startup_failure.SetModuleLifecycleHandler([](
+                                                 const std::string& module_id,
+                                                 framekit::runtime::ModuleLifecyclePhase phase) {
+        if (module_id == "frontend" && phase == framekit::runtime::ModuleLifecyclePhase::kStart) {
+            return false;
+        }
+        return true;
+    });
+
+    REQUIRE(!startup_failure.Start());
+    REQUIRE(startup_failure.State() == framekit::runtime::LifecycleState::kFaulted);
+    REQUIRE(startup_failure.LastFaultReason().find("module start failed: frontend") != std::string::npos);
+    REQUIRE(startup_failure.LastModuleStartupOrder().size() == 1);
+    REQUIRE(startup_failure.LastModuleStartupOrder()[0] == "backend");
+    REQUIRE(startup_failure.Stop());
+    REQUIRE(startup_failure.LastModuleShutdownOrder().size() == 1);
+    REQUIRE(startup_failure.LastModuleShutdownOrder()[0] == "backend");
+
+    framekit::runtime::KernelRuntime invalid_graph;
+    REQUIRE(!invalid_graph.ConfigureModules({
+        framekit::runtime::ModuleSpec{
+            .id = "feature",
+            .required_dependencies = {"missing"},
+            .optional_dependencies = {},
+        },
+    }));
+
+    invalid_graph.SetModuleLifecycleHandler([](
+                                               const std::string& module_id,
+                                               framekit::runtime::ModuleLifecyclePhase phase) {
+        (void)module_id;
+        (void)phase;
+        return true;
+    });
+
+    REQUIRE(!invalid_graph.Start());
+    REQUIRE(invalid_graph.State() == framekit::runtime::LifecycleState::kFaulted);
+    REQUIRE(invalid_graph.LastFaultReason().find("required dependency was not declared") != std::string::npos);
+    REQUIRE(invalid_graph.Stop());
+}
+
 } // namespace
 
 int main() {
@@ -341,5 +456,6 @@ int main() {
     TestModuleGraphValidation();
     TestEventBusSemantics();
     TestKernelRuntime();
+    TestKernelRuntimeModuleLifecycleOrchestration();
     return 0;
 }


### PR DESCRIPTION
Summary:\n- add module graph-driven lifecycle orchestration to KernelRuntime\n- execute initialize/start in deterministic startup order and stop/teardown in reverse order\n- fault startup on invalid graphs or lifecycle callback failures while preserving deterministic observed order\n- extend runtime contract tests for orchestration success, startup failure, and invalid graph paths\n\nValidation:\n- cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON\n- cmake --build build -j4\n- ctest --test-dir build --output-on-failure\n\nCloses #94