### PR TITLE
feat(multiprocess): enforce restart budgets and default policies (#97)

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -5,7 +5,7 @@ FrameKit is a modular framework for building C/C++ applications that may run as 
 Current baseline includes:
 - process role and topology contracts
 - transport-selection contracts
-- multiprocess runtime skeleton
+- multiprocess runtime baseline with deterministic default liveness/supervisor behavior and ProcessSpec restart-budget enforcement
 - lifecycle state machine and kernel runtime start/stop orchestration
 - loop profile and execution-policy validation contracts
 - profile-aware fault-policy runtime with bounded degrade budgets and fail-fast escalation integrated into platform stage-failure handling

--- a/include/framekit/multiprocess/runtime.hpp
+++ b/include/framekit/multiprocess/runtime.hpp
@@ -7,6 +7,7 @@
 #include "framekit/multiprocess/launcher.hpp"
 #include "framekit/multiprocess/supervisor.hpp"
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -43,9 +44,12 @@ public:
 
     void RecordHeartbeat(std::uint64_t process_id, std::uint64_t sequence_id);
     std::uint64_t HeartbeatCount(std::uint64_t process_id) const;
+    std::uint32_t RestartAttemptCount(const std::string& process_name) const;
 
 private:
     bool LaunchChildren();
+    const framekit::ProcessSpec* FindProcessSpec(const framekit::ProcessIdentity& identity) const;
+    bool ConsumeRestartBudget(const framekit::ProcessIdentity& identity);
     bool RelaunchChild(const framekit::ProcessIdentity& old_identity);
 
     framekit::ApplicationSpec spec_;
@@ -56,6 +60,7 @@ private:
     std::vector<framekit::ProcessIdentity> child_processes_;
     std::unordered_map<std::uint64_t, ChildHandshakeStatus> child_handshakes_;
     std::unordered_map<std::uint64_t, std::uint64_t> heartbeat_counters_;
+    std::unordered_map<std::string, std::uint32_t> restart_attempt_counters_;
     bool running_ = false;
 };
 

--- a/src/multiprocess_runtime.cpp
+++ b/src/multiprocess_runtime.cpp
@@ -1,5 +1,42 @@
 #include "framekit/multiprocess/runtime.hpp"
 
+#include <algorithm>
+
+namespace {
+
+class DefaultSupervisorPolicy final : public framekit::runtime::ISupervisorPolicy {
+public:
+    bool ShouldRestart(const framekit::ProcessIdentity& identity, int exit_code) override {
+        (void)identity;
+        (void)exit_code;
+        return true;
+    }
+
+    void OnHeartbeatMissed(const framekit::ProcessIdentity& identity) override {
+        (void)identity;
+    }
+
+    void OnStopped(const framekit::ProcessIdentity& identity) override {
+        (void)identity;
+    }
+};
+
+class DefaultLivenessPolicy final : public framekit::runtime::ILivenessPolicy {
+public:
+    void OnHeartbeat(const framekit::runtime::HeartbeatEvent& event) override {
+        (void)event;
+    }
+
+    bool IsProcessAlive(
+        const framekit::ProcessIdentity& identity,
+        std::uint64_t observed_heartbeat_count) const override {
+        (void)identity;
+        return observed_heartbeat_count > 0;
+    }
+};
+
+} // namespace
+
 namespace framekit::runtime {
 
 void MultiprocessRuntime::Configure(const framekit::ApplicationSpec& spec) {
@@ -27,6 +64,14 @@ bool MultiprocessRuntime::Start() {
         return false;
     }
 
+    if (!supervisor_policy_) {
+        supervisor_policy_ = std::make_shared<DefaultSupervisorPolicy>();
+    }
+
+    if (!liveness_policy_) {
+        liveness_policy_ = std::make_shared<DefaultLivenessPolicy>();
+    }
+
     if (spec_.mode == framekit::AppMode::kMultiProcess && !LaunchChildren()) {
         return false;
     }
@@ -36,18 +81,38 @@ bool MultiprocessRuntime::Start() {
 }
 
 void MultiprocessRuntime::Tick() {
-    if (!supervisor_policy_ || !liveness_policy_) {
+    if (!running_ || !supervisor_policy_ || !liveness_policy_) {
         return;
     }
 
+    std::vector<std::uint64_t> process_ids;
+    process_ids.reserve(child_processes_.size());
     for (const auto& child : child_processes_) {
-        const auto heartbeat_count = HeartbeatCount(child.process_id);
-        if (!liveness_policy_->IsProcessAlive(child, heartbeat_count)) {
-            supervisor_policy_->OnHeartbeatMissed(child);
-        }
+        process_ids.push_back(child.process_id);
     }
 
-    (void)spec_;
+    for (const auto process_id : process_ids) {
+        const auto child_it = std::find_if(
+            child_processes_.begin(),
+            child_processes_.end(),
+            [process_id](const framekit::ProcessIdentity& identity) {
+                return identity.process_id == process_id;
+            });
+
+        if (child_it == child_processes_.end()) {
+            continue;
+        }
+
+        const auto child = *child_it;
+        const auto heartbeat_count = HeartbeatCount(process_id);
+        if (!liveness_policy_->IsProcessAlive(child, heartbeat_count)) {
+            supervisor_policy_->OnHeartbeatMissed(child);
+
+            if (supervisor_policy_->ShouldRestart(child, -1)) {
+                (void)RestartChild(process_id);
+            }
+        }
+    }
 }
 
 void MultiprocessRuntime::Stop() {
@@ -65,11 +130,15 @@ void MultiprocessRuntime::Stop() {
     child_processes_.clear();
     child_handshakes_.clear();
     heartbeat_counters_.clear();
+    restart_attempt_counters_.clear();
 }
 
 bool MultiprocessRuntime::LaunchChildren() {
     child_processes_.clear();
     child_handshakes_.clear();
+    heartbeat_counters_.clear();
+    restart_attempt_counters_.clear();
+
     if (!process_launcher_) {
         return spec_.process_topology.nodes.empty();
     }
@@ -88,9 +157,11 @@ bool MultiprocessRuntime::LaunchChildren() {
         if (!launched.has_value() || !launched->running) {
             return false;
         }
+
         child_processes_.push_back(launched->identity);
         SetChildHandshakeState(launched->identity.process_id, ChildHandshakeState::kSpawned);
         heartbeat_counters_[launched->identity.process_id] = 0;
+        restart_attempt_counters_[node.name] = 0;
     }
 
     return true;
@@ -158,6 +229,41 @@ std::uint64_t MultiprocessRuntime::HeartbeatCount(std::uint64_t process_id) cons
     return it->second;
 }
 
+std::uint32_t MultiprocessRuntime::RestartAttemptCount(const std::string& process_name) const {
+    const auto it = restart_attempt_counters_.find(process_name);
+    if (it == restart_attempt_counters_.end()) {
+        return 0;
+    }
+
+    return it->second;
+}
+
+const framekit::ProcessSpec* MultiprocessRuntime::FindProcessSpec(
+    const framekit::ProcessIdentity& identity) const {
+    for (const auto& spec : spec_.process_topology.nodes) {
+        if (spec.name == identity.role_name && spec.role == identity.role) {
+            return &spec;
+        }
+    }
+
+    return nullptr;
+}
+
+bool MultiprocessRuntime::ConsumeRestartBudget(const framekit::ProcessIdentity& identity) {
+    const auto* process_spec = FindProcessSpec(identity);
+    if (!process_spec || !process_spec->auto_restart) {
+        return false;
+    }
+
+    auto& restart_count = restart_attempt_counters_[process_spec->name];
+    if (restart_count >= process_spec->max_restart_attempts) {
+        return false;
+    }
+
+    restart_count += 1;
+    return true;
+}
+
 bool MultiprocessRuntime::GracefulStopChild(std::uint64_t process_id) {
     if (!process_launcher_) {
         return false;
@@ -200,8 +306,14 @@ bool MultiprocessRuntime::RestartChild(std::uint64_t process_id) {
         if (child.process_id != process_id) {
             continue;
         }
+
+        if (!ConsumeRestartBudget(child)) {
+            return false;
+        }
+
         return RelaunchChild(child);
     }
+
     return false;
 }
 

--- a/tests/test_contracts.cpp
+++ b/tests/test_contracts.cpp
@@ -58,7 +58,8 @@ public:
     bool ShouldRestart(const framekit::ProcessIdentity& identity, int exit_code) override {
         (void)identity;
         (void)exit_code;
-        return false;
+        should_restart_calls += 1;
+        return restart_on_missed;
     }
 
     void OnHeartbeatMissed(const framekit::ProcessIdentity& identity) override {
@@ -69,6 +70,8 @@ public:
         stopped_ids.push_back(identity.process_id);
     }
 
+    int should_restart_calls = 0;
+    bool restart_on_missed = false;
     std::vector<std::uint64_t> missed_heartbeat_ids;
     std::vector<std::uint64_t> stopped_ids;
 };
@@ -145,6 +148,8 @@ int main() {
     backend_spec.name = "backend";
     backend_spec.role = framekit::ProcessRole::kBackend;
     backend_spec.executable_path = "bin/backend_app";
+    backend_spec.auto_restart = true;
+    backend_spec.max_restart_attempts = 2;
     multiprocess_spec.process_topology.nodes.push_back(backend_spec);
 
     auto launcher = std::make_shared<FakeProcessLauncher>();
@@ -181,6 +186,9 @@ int main() {
     runtime.Tick();
     REQUIRE(supervisor->missed_heartbeat_ids.size() == 1);
     REQUIRE(supervisor->missed_heartbeat_ids.front() == child.process_id);
+    REQUIRE(supervisor->should_restart_calls == 1);
+    REQUIRE(runtime.ChildProcesses().size() == 1);
+    REQUIRE(runtime.ChildProcesses().front().process_id == child.process_id);
 
     runtime.RecordHeartbeat(child.process_id, 1);
     REQUIRE(runtime.HeartbeatCount(child.process_id) == 1);
@@ -191,6 +199,7 @@ int main() {
     REQUIRE(supervisor->missed_heartbeat_ids.size() == 1);
 
     REQUIRE(runtime.RestartChild(child.process_id));
+    REQUIRE(runtime.RestartAttemptCount("backend") == 1);
     REQUIRE(lifecycle->restart_requested_ids.size() == 1);
     REQUIRE(lifecycle->restart_requested_ids.front() == child.process_id);
     REQUIRE(lifecycle->restart_from_ids.size() == 1);
@@ -207,6 +216,68 @@ int main() {
 
     runtime.Stop();
     REQUIRE(!runtime.IsRunning());
+
+    framekit::ApplicationSpec defaults_spec;
+    defaults_spec.mode = framekit::AppMode::kMultiProcess;
+
+    framekit::ProcessSpec defaults_backend_spec;
+    defaults_backend_spec.name = "backend-default";
+    defaults_backend_spec.role = framekit::ProcessRole::kBackend;
+    defaults_backend_spec.executable_path = "bin/backend_default_app";
+    defaults_backend_spec.auto_restart = true;
+    defaults_backend_spec.max_restart_attempts = 1;
+    defaults_spec.process_topology.nodes.push_back(defaults_backend_spec);
+
+    framekit::runtime::MultiprocessRuntime defaults_runtime;
+    auto defaults_launcher = std::make_shared<FakeProcessLauncher>();
+    defaults_runtime.Configure(defaults_spec);
+    defaults_runtime.SetProcessLauncher(defaults_launcher);
+
+    REQUIRE(defaults_runtime.Start());
+    REQUIRE(defaults_runtime.ChildProcesses().size() == 1);
+    const auto defaults_initial_pid = defaults_runtime.ChildProcesses().front().process_id;
+
+    defaults_runtime.Tick();
+    REQUIRE(defaults_runtime.ChildProcesses().size() == 1);
+    const auto defaults_restarted_pid = defaults_runtime.ChildProcesses().front().process_id;
+    REQUIRE(defaults_restarted_pid != defaults_initial_pid);
+    REQUIRE(defaults_runtime.RestartAttemptCount("backend-default") == 1);
+
+    defaults_runtime.Tick();
+    REQUIRE(defaults_runtime.ChildProcesses().size() == 1);
+    REQUIRE(defaults_runtime.ChildProcesses().front().process_id == defaults_restarted_pid);
+    REQUIRE(defaults_runtime.RestartAttemptCount("backend-default") == 1);
+
+    defaults_runtime.RecordHeartbeat(defaults_restarted_pid, 1);
+    defaults_runtime.Tick();
+    REQUIRE(defaults_runtime.ChildProcesses().front().process_id == defaults_restarted_pid);
+
+    defaults_runtime.Stop();
+    REQUIRE(!defaults_runtime.IsRunning());
+
+    framekit::ApplicationSpec disabled_restart_spec;
+    disabled_restart_spec.mode = framekit::AppMode::kMultiProcess;
+
+    framekit::ProcessSpec disabled_restart_backend_spec;
+    disabled_restart_backend_spec.name = "backend-no-restart";
+    disabled_restart_backend_spec.role = framekit::ProcessRole::kBackend;
+    disabled_restart_backend_spec.executable_path = "bin/backend_no_restart_app";
+    disabled_restart_backend_spec.auto_restart = false;
+    disabled_restart_backend_spec.max_restart_attempts = 3;
+    disabled_restart_spec.process_topology.nodes.push_back(disabled_restart_backend_spec);
+
+    framekit::runtime::MultiprocessRuntime disabled_restart_runtime;
+    auto disabled_restart_launcher = std::make_shared<FakeProcessLauncher>();
+    disabled_restart_runtime.Configure(disabled_restart_spec);
+    disabled_restart_runtime.SetProcessLauncher(disabled_restart_launcher);
+
+    REQUIRE(disabled_restart_runtime.Start());
+    REQUIRE(disabled_restart_runtime.ChildProcesses().size() == 1);
+    const auto no_restart_pid = disabled_restart_runtime.ChildProcesses().front().process_id;
+    REQUIRE(!disabled_restart_runtime.RestartChild(no_restart_pid));
+    REQUIRE(disabled_restart_runtime.RestartAttemptCount("backend-no-restart") == 0);
+    disabled_restart_runtime.Stop();
+    REQUIRE(!disabled_restart_runtime.IsRunning());
 
     return 0;
 }


### PR DESCRIPTION
Summary:\n- add deterministic default supervisor/liveness behavior when multiprocess runtime policies are not injected\n- enforce restart budgets from ProcessSpec (auto_restart + max_restart_attempts) for explicit and supervisor-triggered restarts\n- expose restart-attempt counters for contract verification\n- expand multiprocess contract tests for default restart path and restart-budget limits\n\nValidation:\n- cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON\n- cmake --build build -j4\n- ctest --test-dir build --output-on-failure\n\nCloses #97