### PR TITLE
feat(multiprocess): transport selection baseline integration (#99)

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -4,7 +4,7 @@ FrameKit is a modular framework for building C/C++ applications that may run as 
 
 Current baseline includes:
 - process role and topology contracts
-- transport-selection contracts
+- transport-selection contracts with multiprocess runtime transport-factory integration baseline
 - multiprocess runtime baseline with deterministic default liveness/supervisor behavior and ProcessSpec restart-budget enforcement
 - lifecycle state machine and kernel runtime start/stop orchestration
 - loop profile and execution-policy validation contracts

--- a/include/framekit/multiprocess/runtime.hpp
+++ b/include/framekit/multiprocess/runtime.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "framekit/ipc/transport.hpp"
 #include "framekit/spec/app_spec.hpp"
 #include "framekit/multiprocess/handshake.hpp"
 #include "framekit/lifecycle/hooks.hpp"
@@ -23,6 +24,7 @@ public:
     void Configure(const framekit::ApplicationSpec& spec);
     void SetSupervisorPolicy(std::shared_ptr<ISupervisorPolicy> policy);
     void SetProcessLauncher(std::shared_ptr<IProcessLauncher> launcher);
+    void SetTransportFactory(std::shared_ptr<framekit::ipc::ITransportFactory> factory);
     void SetLivenessPolicy(std::shared_ptr<ILivenessPolicy> policy);
     void SetLifecycleHooks(std::shared_ptr<ILifecycleHooks> hooks);
 
@@ -45,8 +47,12 @@ public:
     void RecordHeartbeat(std::uint64_t process_id, std::uint64_t sequence_id);
     std::uint64_t HeartbeatCount(std::uint64_t process_id) const;
     std::uint32_t RestartAttemptCount(const std::string& process_name) const;
+    bool HasActiveTransport() const;
+    const framekit::ipc::TransportConfig& ActiveTransportConfig() const;
+    const std::string& LastError() const;
 
 private:
+    bool ConfigureTransport();
     bool LaunchChildren();
     const framekit::ProcessSpec* FindProcessSpec(const framekit::ProcessIdentity& identity) const;
     bool ConsumeRestartBudget(const framekit::ProcessIdentity& identity);
@@ -55,12 +61,16 @@ private:
     framekit::ApplicationSpec spec_;
     std::shared_ptr<ISupervisorPolicy> supervisor_policy_;
     std::shared_ptr<IProcessLauncher> process_launcher_;
+    std::shared_ptr<framekit::ipc::ITransportFactory> transport_factory_;
     std::shared_ptr<ILivenessPolicy> liveness_policy_;
     std::shared_ptr<ILifecycleHooks> lifecycle_hooks_;
+    framekit::ipc::TransportBundle transport_bundle_;
+    framekit::ipc::TransportConfig active_transport_config_;
     std::vector<framekit::ProcessIdentity> child_processes_;
     std::unordered_map<std::uint64_t, ChildHandshakeStatus> child_handshakes_;
     std::unordered_map<std::uint64_t, std::uint64_t> heartbeat_counters_;
     std::unordered_map<std::string, std::uint32_t> restart_attempt_counters_;
+    std::string last_error_;
     bool running_ = false;
 };
 

--- a/src/multiprocess_runtime.cpp
+++ b/src/multiprocess_runtime.cpp
@@ -4,6 +4,21 @@
 
 namespace {
 
+const char* TransportKindName(framekit::IpcTransportKind kind) {
+    switch (kind) {
+        case framekit::IpcTransportKind::kNone:
+            return "none";
+        case framekit::IpcTransportKind::kShmPipe:
+            return "shm_pipe";
+        case framekit::IpcTransportKind::kLocalSocket:
+            return "local_socket";
+        case framekit::IpcTransportKind::kCustom:
+            return "custom";
+    }
+
+    return "unknown";
+}
+
 class DefaultSupervisorPolicy final : public framekit::runtime::ISupervisorPolicy {
 public:
     bool ShouldRestart(const framekit::ProcessIdentity& identity, int exit_code) override {
@@ -51,6 +66,10 @@ void MultiprocessRuntime::SetProcessLauncher(std::shared_ptr<IProcessLauncher> l
     process_launcher_ = std::move(launcher);
 }
 
+void MultiprocessRuntime::SetTransportFactory(std::shared_ptr<framekit::ipc::ITransportFactory> factory) {
+    transport_factory_ = std::move(factory);
+}
+
 void MultiprocessRuntime::SetLivenessPolicy(std::shared_ptr<ILivenessPolicy> policy) {
     liveness_policy_ = std::move(policy);
 }
@@ -61,8 +80,11 @@ void MultiprocessRuntime::SetLifecycleHooks(std::shared_ptr<ILifecycleHooks> hoo
 
 bool MultiprocessRuntime::Start() {
     if (running_) {
+        last_error_ = "multiprocess runtime is already running";
         return false;
     }
+
+    last_error_.clear();
 
     if (!supervisor_policy_) {
         supervisor_policy_ = std::make_shared<DefaultSupervisorPolicy>();
@@ -72,8 +94,22 @@ bool MultiprocessRuntime::Start() {
         liveness_policy_ = std::make_shared<DefaultLivenessPolicy>();
     }
 
-    if (spec_.mode == framekit::AppMode::kMultiProcess && !LaunchChildren()) {
-        return false;
+    if (spec_.mode == framekit::AppMode::kMultiProcess) {
+        if (spec_.transport_kind != framekit::IpcTransportKind::kNone && !ConfigureTransport()) {
+            return false;
+        }
+
+        if (!LaunchChildren()) {
+            if (transport_bundle_.control_channel) {
+                transport_bundle_.control_channel->Close();
+            }
+            transport_bundle_ = {};
+            active_transport_config_ = {};
+            if (last_error_.empty()) {
+                last_error_ = "failed to launch child processes";
+            }
+            return false;
+        }
     }
 
     running_ = true;
@@ -131,6 +167,48 @@ void MultiprocessRuntime::Stop() {
     child_handshakes_.clear();
     heartbeat_counters_.clear();
     restart_attempt_counters_.clear();
+
+    if (transport_bundle_.control_channel) {
+        transport_bundle_.control_channel->Close();
+    }
+    transport_bundle_ = {};
+    active_transport_config_ = {};
+    last_error_.clear();
+}
+
+bool MultiprocessRuntime::ConfigureTransport() {
+    if (!transport_factory_) {
+        last_error_ = "transport factory is required when transport_kind is not none";
+        return false;
+    }
+
+    framekit::ipc::TransportConfig config;
+    config.name = TransportKindName(spec_.transport_kind);
+    config.values["application"] = spec_.application_name;
+    config.values["profile"] = spec_.transport_profile;
+    config.values["kind"] = config.name;
+
+    auto bundle = transport_factory_->Create(config);
+    if (!bundle.control_channel) {
+        last_error_ = "transport factory returned null control channel";
+        return false;
+    }
+
+    if (!bundle.control_channel->IsOpen()) {
+        bundle.control_channel->Close();
+        last_error_ = "transport control channel is not open";
+        return false;
+    }
+
+    if (!bundle.data_plane) {
+        bundle.control_channel->Close();
+        last_error_ = "transport factory returned null data plane";
+        return false;
+    }
+
+    active_transport_config_ = std::move(config);
+    transport_bundle_ = std::move(bundle);
+    return true;
 }
 
 bool MultiprocessRuntime::LaunchChildren() {
@@ -140,7 +218,12 @@ bool MultiprocessRuntime::LaunchChildren() {
     restart_attempt_counters_.clear();
 
     if (!process_launcher_) {
-        return spec_.process_topology.nodes.empty();
+        if (!spec_.process_topology.nodes.empty()) {
+            last_error_ = "process launcher is required for non-empty process topology";
+            return false;
+        }
+
+        return true;
     }
 
     framekit::ProcessIdentity parent_identity;
@@ -155,6 +238,7 @@ bool MultiprocessRuntime::LaunchChildren() {
 
         auto launched = process_launcher_->LaunchChild(parent_identity, node);
         if (!launched.has_value() || !launched->running) {
+            last_error_ = "failed to launch child process: " + node.name;
             return false;
         }
 
@@ -238,6 +322,20 @@ std::uint32_t MultiprocessRuntime::RestartAttemptCount(const std::string& proces
     return it->second;
 }
 
+bool MultiprocessRuntime::HasActiveTransport() const {
+    return transport_bundle_.control_channel &&
+        transport_bundle_.data_plane &&
+        transport_bundle_.control_channel->IsOpen();
+}
+
+const framekit::ipc::TransportConfig& MultiprocessRuntime::ActiveTransportConfig() const {
+    return active_transport_config_;
+}
+
+const std::string& MultiprocessRuntime::LastError() const {
+    return last_error_;
+}
+
 const framekit::ProcessSpec* MultiprocessRuntime::FindProcessSpec(
     const framekit::ProcessIdentity& identity) const {
     for (const auto& spec : spec_.process_topology.nodes) {
@@ -251,12 +349,19 @@ const framekit::ProcessSpec* MultiprocessRuntime::FindProcessSpec(
 
 bool MultiprocessRuntime::ConsumeRestartBudget(const framekit::ProcessIdentity& identity) {
     const auto* process_spec = FindProcessSpec(identity);
-    if (!process_spec || !process_spec->auto_restart) {
+    if (!process_spec) {
+        last_error_ = "process spec not found for restart target";
+        return false;
+    }
+
+    if (!process_spec->auto_restart) {
+        last_error_ = "auto restart is disabled for process: " + process_spec->name;
         return false;
     }
 
     auto& restart_count = restart_attempt_counters_[process_spec->name];
     if (restart_count >= process_spec->max_restart_attempts) {
+        last_error_ = "restart budget exhausted for process: " + process_spec->name;
         return false;
     }
 
@@ -266,6 +371,7 @@ bool MultiprocessRuntime::ConsumeRestartBudget(const framekit::ProcessIdentity& 
 
 bool MultiprocessRuntime::GracefulStopChild(std::uint64_t process_id) {
     if (!process_launcher_) {
+        last_error_ = "process launcher is not configured";
         return false;
     }
 
@@ -289,6 +395,7 @@ bool MultiprocessRuntime::GracefulStopChild(std::uint64_t process_id) {
         }
 
         if (!stopped) {
+            last_error_ = "failed to stop child process";
             return false;
         }
 
@@ -298,10 +405,13 @@ bool MultiprocessRuntime::GracefulStopChild(std::uint64_t process_id) {
         return true;
     }
 
+    last_error_ = "child process not found";
     return false;
 }
 
 bool MultiprocessRuntime::RestartChild(std::uint64_t process_id) {
+    last_error_.clear();
+
     for (const auto& child : child_processes_) {
         if (child.process_id != process_id) {
             continue;
@@ -314,11 +424,13 @@ bool MultiprocessRuntime::RestartChild(std::uint64_t process_id) {
         return RelaunchChild(child);
     }
 
+    last_error_ = "child process not found for restart";
     return false;
 }
 
 bool MultiprocessRuntime::RelaunchChild(const framekit::ProcessIdentity& old_identity) {
     if (!process_launcher_) {
+        last_error_ = "process launcher is not configured";
         return false;
     }
 
@@ -327,6 +439,7 @@ bool MultiprocessRuntime::RelaunchChild(const framekit::ProcessIdentity& old_ide
     }
 
     if (!process_launcher_->StopChild(old_identity)) {
+        last_error_ = "failed to stop child process before restart";
         if (lifecycle_hooks_) {
             lifecycle_hooks_->OnRestartCompleted(old_identity, old_identity, false);
         }
@@ -350,6 +463,7 @@ bool MultiprocessRuntime::RelaunchChild(const framekit::ProcessIdentity& old_ide
 
             auto relaunched = process_launcher_->LaunchChild(parent_identity, spec);
             if (!relaunched.has_value() || !relaunched->running) {
+                last_error_ = "failed to relaunch child process";
                 if (lifecycle_hooks_) {
                     lifecycle_hooks_->OnRestartCompleted(old_identity, old_identity, false);
                 }
@@ -371,10 +485,13 @@ bool MultiprocessRuntime::RelaunchChild(const framekit::ProcessIdentity& old_ide
             if (lifecycle_hooks_) {
                 lifecycle_hooks_->OnRestartCompleted(old_identity, new_identity, true);
             }
+
+            last_error_.clear();
             return true;
         }
     }
 
+    last_error_ = "process spec not found for restart";
     if (lifecycle_hooks_) {
         lifecycle_hooks_->OnRestartCompleted(old_identity, old_identity, false);
     }

--- a/tests/test_contracts.cpp
+++ b/tests/test_contracts.cpp
@@ -126,6 +126,95 @@ public:
     std::vector<std::uint64_t> restart_to_ids;
 };
 
+class FakeControlChannel : public framekit::ipc::IControlChannel {
+public:
+    bool Send(const framekit::ipc::ControlMessage& message) override {
+        if (!open) {
+            return false;
+        }
+
+        sent_messages.push_back(message);
+        return true;
+    }
+
+    std::optional<framekit::ipc::ControlMessage> Receive() override {
+        return next_message;
+    }
+
+    bool IsOpen() const override {
+        return open;
+    }
+
+    void Close() override {
+        open = false;
+        close_calls += 1;
+    }
+
+    bool open = true;
+    int close_calls = 0;
+    std::vector<framekit::ipc::ControlMessage> sent_messages;
+    std::optional<framekit::ipc::ControlMessage> next_message;
+};
+
+class FakeDataPlane : public framekit::ipc::IDataPlane {
+public:
+    bool Write(const std::uint8_t* data, std::size_t size) override {
+        if (size > capacity) {
+            return false;
+        }
+
+        written.assign(data, data + size);
+        return true;
+    }
+
+    std::vector<std::uint8_t> Read() override {
+        return written;
+    }
+
+    std::size_t Capacity() const override {
+        return capacity;
+    }
+
+    std::size_t capacity = 1024;
+    std::vector<std::uint8_t> written;
+};
+
+class FakeTransportFactory : public framekit::ipc::ITransportFactory {
+public:
+    framekit::ipc::TransportBundle Create(const framekit::ipc::TransportConfig& config) override {
+        create_calls += 1;
+        last_config = config;
+
+        framekit::ipc::TransportBundle bundle;
+        if (!return_null_control_channel) {
+            auto control = std::make_unique<FakeControlChannel>();
+            control->open = !return_closed_control_channel;
+            last_control_channel = control.get();
+            bundle.control_channel = std::move(control);
+        } else {
+            last_control_channel = nullptr;
+        }
+
+        if (!return_null_data_plane) {
+            auto data = std::make_unique<FakeDataPlane>();
+            last_data_plane = data.get();
+            bundle.data_plane = std::move(data);
+        } else {
+            last_data_plane = nullptr;
+        }
+
+        return bundle;
+    }
+
+    int create_calls = 0;
+    bool return_null_control_channel = false;
+    bool return_null_data_plane = false;
+    bool return_closed_control_channel = false;
+    framekit::ipc::TransportConfig last_config;
+    FakeControlChannel* last_control_channel = nullptr;
+    FakeDataPlane* last_data_plane = nullptr;
+};
+
 } // namespace
 
 int main() {
@@ -278,6 +367,77 @@ int main() {
     REQUIRE(disabled_restart_runtime.RestartAttemptCount("backend-no-restart") == 0);
     disabled_restart_runtime.Stop();
     REQUIRE(!disabled_restart_runtime.IsRunning());
+
+    framekit::ApplicationSpec transport_spec;
+    transport_spec.application_name = "framekit-transport-test";
+    transport_spec.mode = framekit::AppMode::kMultiProcess;
+    transport_spec.transport_kind = framekit::IpcTransportKind::kShmPipe;
+    transport_spec.transport_profile = "integration";
+
+    framekit::ProcessSpec transport_backend_spec;
+    transport_backend_spec.name = "backend-transport";
+    transport_backend_spec.role = framekit::ProcessRole::kBackend;
+    transport_backend_spec.executable_path = "bin/backend_transport";
+    transport_spec.process_topology.nodes.push_back(transport_backend_spec);
+
+    framekit::runtime::MultiprocessRuntime no_factory_transport_runtime;
+    auto no_factory_launcher = std::make_shared<FakeProcessLauncher>();
+    no_factory_transport_runtime.Configure(transport_spec);
+    no_factory_transport_runtime.SetProcessLauncher(no_factory_launcher);
+    REQUIRE(!no_factory_transport_runtime.Start());
+    REQUIRE(no_factory_transport_runtime.LastError().find("transport factory is required") != std::string::npos);
+
+    framekit::runtime::MultiprocessRuntime invalid_transport_runtime;
+    auto invalid_launcher = std::make_shared<FakeProcessLauncher>();
+    auto invalid_factory = std::make_shared<FakeTransportFactory>();
+    invalid_factory->return_null_data_plane = true;
+    invalid_transport_runtime.Configure(transport_spec);
+    invalid_transport_runtime.SetProcessLauncher(invalid_launcher);
+    invalid_transport_runtime.SetTransportFactory(invalid_factory);
+    REQUIRE(!invalid_transport_runtime.Start());
+    REQUIRE(invalid_transport_runtime.LastError().find("null data plane") != std::string::npos);
+
+    framekit::runtime::MultiprocessRuntime closed_control_runtime;
+    auto closed_control_launcher = std::make_shared<FakeProcessLauncher>();
+    auto closed_control_factory = std::make_shared<FakeTransportFactory>();
+    closed_control_factory->return_closed_control_channel = true;
+    closed_control_runtime.Configure(transport_spec);
+    closed_control_runtime.SetProcessLauncher(closed_control_launcher);
+    closed_control_runtime.SetTransportFactory(closed_control_factory);
+    REQUIRE(!closed_control_runtime.Start());
+    REQUIRE(closed_control_runtime.LastError().find("not open") != std::string::npos);
+
+    framekit::ApplicationSpec valid_transport_spec = transport_spec;
+    valid_transport_spec.transport_kind = framekit::IpcTransportKind::kLocalSocket;
+    valid_transport_spec.transport_profile = "local-latency";
+
+    framekit::runtime::MultiprocessRuntime valid_transport_runtime;
+    auto valid_transport_launcher = std::make_shared<FakeProcessLauncher>();
+    auto valid_transport_factory = std::make_shared<FakeTransportFactory>();
+    valid_transport_runtime.Configure(valid_transport_spec);
+    valid_transport_runtime.SetProcessLauncher(valid_transport_launcher);
+    valid_transport_runtime.SetTransportFactory(valid_transport_factory);
+    REQUIRE(valid_transport_runtime.Start());
+    REQUIRE(valid_transport_runtime.IsRunning());
+    REQUIRE(valid_transport_runtime.HasActiveTransport());
+    REQUIRE(valid_transport_factory->create_calls == 1);
+
+    const auto& active_transport_config = valid_transport_runtime.ActiveTransportConfig();
+    REQUIRE(active_transport_config.name == "local_socket");
+
+    const auto profile_it = active_transport_config.values.find("profile");
+    REQUIRE(profile_it != active_transport_config.values.end());
+    REQUIRE(profile_it->second == "local-latency");
+
+    const auto app_it = active_transport_config.values.find("application");
+    REQUIRE(app_it != active_transport_config.values.end());
+    REQUIRE(app_it->second == "framekit-transport-test");
+
+    valid_transport_runtime.Stop();
+    REQUIRE(!valid_transport_runtime.IsRunning());
+    REQUIRE(!valid_transport_runtime.HasActiveTransport());
+    REQUIRE(valid_transport_factory->create_calls == 1);
+    REQUIRE(valid_transport_runtime.LastError().empty());
 
     return 0;
 }


### PR DESCRIPTION
Summary:\n- integrate runtime transport-factory setup into multiprocess start/stop lifecycle\n- add deterministic transport validation and LastError reasons for invalid bundles\n- add contract tests for required factory, invalid transport bundles, and successful transport activation\n- update overview baseline note for transport-factory integration\n\nValidation:\n- cmake --build build -j4\n- ctest --test-dir build --output-on-failure\n\nCloses #99