### PR TITLE
fix(multiprocess): preserve rollback-failed child state (#103)

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -5,7 +5,7 @@ FrameKit is a modular framework for building C/C++ applications that may run as 
 Current baseline includes:
 - process role and topology contracts
 - transport-selection contracts with multiprocess runtime transport-factory integration baseline
-- multiprocess runtime baseline with deterministic default liveness/supervisor behavior, ProcessSpec restart-budget enforcement, and partial-launch rollback guarantees
+- multiprocess runtime baseline with deterministic default liveness/supervisor behavior, ProcessSpec restart-budget enforcement, partial-launch rollback guarantees, and rollback-failure cleanup state retention
 - lifecycle state machine and kernel runtime start/stop orchestration
 - loop profile and execution-policy validation contracts
 - profile-aware fault-policy runtime with bounded degrade budgets and fail-fast escalation integrated into platform stage-failure handling

--- a/src/multiprocess_runtime.cpp
+++ b/src/multiprocess_runtime.cpp
@@ -232,19 +232,38 @@ bool MultiprocessRuntime::LaunchChildren() {
     parent_identity.process_id = 1;
 
     const auto rollback_launch_state = [this]() {
-        bool rollback_succeeded = true;
+        std::vector<framekit::ProcessIdentity> rollback_failed_children;
 
         for (auto it = child_processes_.rbegin(); it != child_processes_.rend(); ++it) {
             if (!process_launcher_->StopChild(*it)) {
-                rollback_succeeded = false;
+                rollback_failed_children.push_back(*it);
             }
         }
 
-        child_processes_.clear();
         child_handshakes_.clear();
         heartbeat_counters_.clear();
         restart_attempt_counters_.clear();
-        return rollback_succeeded;
+
+        if (rollback_failed_children.empty()) {
+            child_processes_.clear();
+            return true;
+        }
+
+        std::reverse(rollback_failed_children.begin(), rollback_failed_children.end());
+        child_processes_ = std::move(rollback_failed_children);
+        for (const auto& child_identity : child_processes_) {
+            child_handshakes_[child_identity.process_id] = ChildHandshakeStatus{
+                .child = child_identity,
+                .state = ChildHandshakeState::kSpawned,
+                .detail = "rollback-stop-failed"};
+            heartbeat_counters_[child_identity.process_id] = 0;
+
+            if (const auto* process_spec = FindProcessSpec(child_identity)) {
+                restart_attempt_counters_[process_spec->name] = 0;
+            }
+        }
+
+        return false;
     };
 
     for (const auto& node : spec_.process_topology.nodes) {

--- a/tests/test_contracts.cpp
+++ b/tests/test_contracts.cpp
@@ -42,6 +42,11 @@ public:
 
     bool StopChild(const framekit::ProcessIdentity& identity) override {
         stop_calls += 1;
+
+        if (!fail_stop_role_name.empty() && fail_stop_role_name == identity.role_name) {
+            return false;
+        }
+
         for (auto it = running_.begin(); it != running_.end(); ++it) {
             if (it->process_id == identity.process_id) {
                 running_.erase(it);
@@ -58,6 +63,7 @@ public:
     int launch_calls = 0;
     int stop_calls = 0;
     std::string fail_launch_role_name;
+    std::string fail_stop_role_name;
 
 private:
     std::uint64_t next_pid_ = 42;
@@ -402,11 +408,36 @@ int main() {
 
     REQUIRE(!partial_launch_failure_runtime.Start());
     REQUIRE(partial_launch_failure_runtime.LastError().find("failed to launch child process: launch-worker") != std::string::npos);
+    REQUIRE(partial_launch_failure_runtime.LastError().find("rollback stop failed") == std::string::npos);
     REQUIRE(partial_launch_failure_runtime.ChildProcesses().empty());
     REQUIRE(partial_launch_failure_runtime.AllChildHandshakes().empty());
     REQUIRE(partial_launch_failure_launcher->launch_calls == 2);
     REQUIRE(partial_launch_failure_launcher->stop_calls == 1);
     REQUIRE(partial_launch_failure_launcher->RunningChildren().empty());
+
+    framekit::runtime::MultiprocessRuntime rollback_stop_failure_runtime;
+    auto rollback_stop_failure_launcher = std::make_shared<FakeProcessLauncher>();
+    rollback_stop_failure_launcher->fail_launch_role_name = "launch-worker";
+    rollback_stop_failure_launcher->fail_stop_role_name = "launch-backend";
+    rollback_stop_failure_runtime.Configure(partial_launch_failure_spec);
+    rollback_stop_failure_runtime.SetProcessLauncher(rollback_stop_failure_launcher);
+
+    REQUIRE(!rollback_stop_failure_runtime.Start());
+    REQUIRE(rollback_stop_failure_runtime.LastError().find("failed to launch child process: launch-worker") != std::string::npos);
+    REQUIRE(rollback_stop_failure_runtime.LastError().find("rollback stop failed") != std::string::npos);
+    REQUIRE(rollback_stop_failure_runtime.ChildProcesses().size() == 1);
+    REQUIRE(rollback_stop_failure_runtime.ChildProcesses().front().role_name == "launch-backend");
+
+    const auto rollback_stop_failure_handshake = rollback_stop_failure_runtime.ChildHandshake(
+        rollback_stop_failure_runtime.ChildProcesses().front().process_id);
+    REQUIRE(rollback_stop_failure_handshake.has_value());
+    REQUIRE(rollback_stop_failure_handshake->detail == "rollback-stop-failed");
+    REQUIRE(rollback_stop_failure_launcher->RunningChildren().size() == 1);
+
+    rollback_stop_failure_launcher->fail_stop_role_name.clear();
+    rollback_stop_failure_runtime.Stop();
+    REQUIRE(rollback_stop_failure_runtime.ChildProcesses().empty());
+    REQUIRE(rollback_stop_failure_launcher->RunningChildren().empty());
 
     framekit::ApplicationSpec transport_spec;
     transport_spec.application_name = "framekit-transport-test";


### PR DESCRIPTION
Summary:\n- modify partial-launch rollback to retain runtime state only for children that failed to stop\n- record explicit `rollback-stop-failed` status detail for retained children\n- add contract coverage for simulated rollback stop failures\n- update baseline overview doc to state rollback-failure cleanup guarantees\n\nValidation:\n- cmake --build build -j4\n- ctest --test-dir build --output-on-failure\n\nCloses #103