### PR TITLE
ci(cpp): expand v2 release matrix coverage (#107)

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -22,6 +22,43 @@ jobs:
       - name: Test
         run: ctest --test-dir build --output-on-failure
 
+  linux-clang:
+    name: linux-clang
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure
+        run: cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
+  macos-clang:
+    name: macos-clang
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure
+        run: cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
   framekit-with-netkit:
     name: netkit-shmpipe
     runs-on: ubuntu-latest
@@ -38,6 +75,50 @@ jobs:
 
       - name: Configure
         run: cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=ON -DFRAMEKIT_NETKIT_SOURCE_DIR=${{ github.workspace }}/netkit -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
+  framekit-with-netkit-macos:
+    name: netkit-shmpipe-macos
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout framekit
+        uses: actions/checkout@v4
+
+      - name: Checkout netkit
+        uses: actions/checkout@v4
+        with:
+          repository: tinmanworks-framekit/netkit
+          path: netkit
+
+      - name: Configure
+        run: cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=ON -DFRAMEKIT_NETKIT_SOURCE_DIR=${{ github.workspace }}/netkit -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
+  sanitizer-linux:
+    name: sanitizer-linux-clang
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+      SANITIZER_FLAGS: -fsanitize=address,undefined -fno-omit-frame-pointer
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure
+        run: cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="${SANITIZER_FLAGS}" -DCMAKE_CXX_FLAGS="${SANITIZER_FLAGS}" -DCMAKE_EXE_LINKER_FLAGS="${SANITIZER_FLAGS}" -DCMAKE_SHARED_LINKER_FLAGS="${SANITIZER_FLAGS}"
 
       - name: Build
         run: cmake --build build


### PR DESCRIPTION
Summary:
- keep the canonical smoke check intact for branch protection
- add supplemental Linux Clang, macOS Clang, macOS NetKit, and sanitizer coverage
- retain the existing NetKit Linux path and validate local core/netkit builds

Validation:
- cmake -S . -B build-ci-core -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF
- cmake --build build-ci-core -j4
- ctest --test-dir build-ci-core --output-on-failure
- cmake -S . -B build-ci-netkit -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=ON -DFRAMEKIT_NETKIT_SOURCE_DIR=../netkit
- cmake --build build-ci-netkit -j4
- ctest --test-dir build-ci-netkit --output-on-failure

Closes #107