### PR TITLE
build(release): cut over versioning to v2.0.0 (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
 ## Unreleased
-- Initial doctrine-aligned baseline scaffold.
-- Initial multiprocess contract and runtime skeleton.
+- Release-evidence updates for the `v2.0.0` promotion flow.
+
+## v2.0.0
+- First public release of the rewritten, incompatible FrameKit v2 line.
+- Added a contracts-first public API under `include/framekit/*`.
+- Added runtime implementations for lifecycle, loop, input, platform, fault policy, kernel, and multiprocess orchestration.
+- Added optional NetKit-linked examples and selective-linking guidance.
+- Added governance, ADR, and release workflow documentation for the v2 line.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.23)
 
-project(framekit VERSION 0.1.0 LANGUAGES C CXX)
+project(framekit VERSION 2.0.0 LANGUAGES C CXX)
 
 option(FRAMEKIT_BUILD_TESTS "Build framekit tests" ON)
 option(FRAMEKIT_BUILD_EXAMPLES "Build framekit examples" ON)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,31 @@
+# Release Notes
+
+## FrameKit v2.0.0
+
+Status: Draft
+Last Updated: 2026-03-29
+
+### Summary
+
+FrameKit v2.0.0 is the first public release of the rewritten FrameKit v2 line.
+It replaces the earlier baseline with a contracts-first, incompatible release.
+
+### Highlights
+
+- Stable contract headers organized under `include/framekit/*`.
+- Runtime implementations for lifecycle, loop, input, platform, fault policy, kernel, and multiprocess orchestration.
+- Optional NetKit-linked frontend/backend examples and selective-linking guidance.
+- Cross-platform CI coverage for core, NetKit-enabled, and sanitizer validation paths.
+- Governance, ADR, and release-playbook documentation aligned to the v2 release flow.
+
+### Compatibility
+
+- This release is intentionally not backward compatible with the earlier FrameKit line.
+- Historical `v0.1.0` artifacts remain archived and are not the basis for this release.
+
+### Release Evidence
+
+- CI expansion issue: #107
+- Release cutover issue: #108
+- Release promotion PR: pending
+- Signed tag: pending

--- a/docs/doctrine/api-doc-contract-alignment-2026-03-29.md
+++ b/docs/doctrine/api-doc-contract-alignment-2026-03-29.md
@@ -19,4 +19,4 @@ It reviews alignment between the implemented contracts located across `include/f
 - `include/framekit/loop/stage_graph.hpp` and `include/framekit/loop/policy.hpp` fully cover constraints defined in `loop-stage-graph-profiles.md`.
 - `include/framekit/ipc/*` and `include/framekit/multiprocess/*` headers match transport selection behaviors dictated by `integration-boundary.md` and Phase 2 specifications.
 
-All discrepancies resolved and verified against the FrameKit v0.1.0 boundary layout.
+All discrepancies resolved and verified against the FrameKit v2.0.0 boundary layout.


### PR DESCRIPTION
Summary:
- bump the project version from 0.1.0 to 2.0.0 for the rewritten FrameKit line
- add release notes and refresh changelog content for the v2.0.0 release target
- update the contract-alignment audit artifact so it points at the active v2.0.0 boundary line

Validation:
- cmake -S . -B build-v2-core -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF
- cmake --build build-v2-core -j4
- ctest --test-dir build-v2-core --output-on-failure
- cmake -S . -B build-v2-netkit -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=ON -DFRAMEKIT_NETKIT_SOURCE_DIR=../netkit
- cmake --build build-v2-netkit -j4
- ctest --test-dir build-v2-netkit --output-on-failure

Closes #108