### PR TITLE
docs(release): sync published v2 notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## FrameKit v2.0.0
 
-Status: Draft
+Status: Published
 Last Updated: 2026-03-29
 
 ### Summary
@@ -27,5 +27,5 @@ It replaces the earlier baseline with a contracts-first, incompatible release.
 
 - CI expansion issue: #107
 - Release cutover issue: #108
-- Release promotion PR: pending
-- Signed tag: pending
+- Release promotion PR: #111
+- Signed tag: v2.0.0


### PR DESCRIPTION
## Summary
- align the checked-in `RELEASE_NOTES.md` file with the already-published `v2.0.0` release page
- replace the stale `Status: Draft` wording with `Status: Published`
- record the actual release promotion PR and signed tag in the repo copy

## Validation
- reviewed the repo-side release notes diff locally
- confirmed the published GitHub release already uses the same final values

Refs #108
