### PR TITLE
feat(platform): add experimental cocoa auto-wiring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,21 @@ project(framekit VERSION 2.0.0 LANGUAGES C CXX)
 option(FRAMEKIT_BUILD_TESTS "Build framekit tests" ON)
 option(FRAMEKIT_BUILD_EXAMPLES "Build framekit examples" ON)
 option(FRAMEKIT_ENABLE_NETKIT "Enable NetKit-dependent framekit integrations" OFF)
+option(FRAMEKIT_ENABLE_COCOA "Enable experimental macOS Cocoa backend support" OFF)
 
 set(FRAMEKIT_NETKIT_SOURCE_DIR "" CACHE PATH "Path to netkit source directory")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(FRAMEKIT_ENABLE_COCOA AND NOT APPLE)
+    message(FATAL_ERROR "FRAMEKIT_ENABLE_COCOA is only supported on macOS")
+endif()
+
+if(FRAMEKIT_ENABLE_COCOA)
+    enable_language(OBJCXX)
+endif()
 
 add_library(framekit_core STATIC
     src/multiprocess_runtime.cpp
@@ -25,6 +34,16 @@ add_library(framekit_core STATIC
     src/bootstrap_services.cpp
     src/kernel_runtime.cpp
 )
+
+if(FRAMEKIT_ENABLE_COCOA)
+    target_sources(framekit_core PRIVATE
+        src/cocoa_platform_backend.mm
+    )
+else()
+    target_sources(framekit_core PRIVATE
+        src/platform_backend_factory_stub.cpp
+    )
+endif()
 add_library(FrameKit::Core ALIAS framekit_core)
 
 target_include_directories(framekit_core
@@ -34,6 +53,13 @@ target_include_directories(framekit_core
 )
 
 target_compile_features(framekit_core PUBLIC cxx_std_20)
+
+if(FRAMEKIT_ENABLE_COCOA)
+    target_link_libraries(framekit_core PRIVATE "-framework AppKit")
+    target_compile_options(framekit_core PRIVATE
+        $<$<COMPILE_LANGUAGE:OBJCXX>:-fobjc-arc>
+    )
+endif()
 
 if(FRAMEKIT_BUILD_EXAMPLES)
     add_executable(framekit_single_process_example

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Modular C/C++ application framework focused on single-process and multiprocess a
 - A runtime framework for building frontend/backend/worker style apps.
 - A contracts-first core where transport implementations can be optional.
 - A host for integrations with `netkit` and `mediakit`.
-- A window backend contract with an Apple Cocoa module implementation.
+- A window backend contract with experimental Apple Cocoa support on macOS.
 
 ## Multiprocess Direction
 `framekit` owns multiprocess orchestration contracts and runtime behavior. Transport implementations are optional and supplied by `netkit`.
@@ -47,7 +47,7 @@ Core sample executables:
 - `framekit_single_process_example`
 - `framekit_multi_worker_example`
 
-Apple Cocoa backend module:
+Experimental Apple Cocoa backend (local/macOS only until dedicated validation lands):
 ```bash
 cmake -S . -B build \
   -DFRAMEKIT_BUILD_TESTS=ON \
@@ -55,6 +55,10 @@ cmake -S . -B build \
   -DFRAMEKIT_ENABLE_COCOA=ON
 cmake --build build
 ```
+
+When enabled on macOS, `PlatformHostRuntime` auto-wires Cocoa platform/window
+hosts for GUI and Hybrid render-active usage if no hosts are injected
+explicitly.
 
 ## Attribution Request
 If you use FrameKit in your project, please mention FrameKit and credit George Gil / TinMan in your project documentation.

--- a/src/cocoa_platform_backend.mm
+++ b/src/cocoa_platform_backend.mm
@@ -1,0 +1,136 @@
+#include "platform_backend_factory_internal.hpp"
+
+#import <AppKit/AppKit.h>
+
+namespace framekit::runtime::detail {
+
+namespace {
+
+class CocoaPlatformHost final : public IPlatformHost {
+public:
+    bool Initialize() override {
+        @autoreleasepool {
+            if (![NSThread isMainThread]) {
+                return false;
+            }
+
+            app_ = [NSApplication sharedApplication];
+            if (!app_) {
+                return false;
+            }
+
+            [app_ setActivationPolicy:NSApplicationActivationPolicyRegular];
+            return true;
+        }
+    }
+
+    bool PumpEvents() override {
+        @autoreleasepool {
+            if (!app_) {
+                return false;
+            }
+
+            for (;;) {
+                NSEvent* event = [app_ nextEventMatchingMask:NSEventMaskAny
+                                                   untilDate:[NSDate distantPast]
+                                                      inMode:NSDefaultRunLoopMode
+                                                     dequeue:YES];
+                if (!event) {
+                    break;
+                }
+
+                [app_ sendEvent:event];
+            }
+
+            [app_ updateWindows];
+            return true;
+        }
+    }
+
+    bool Teardown() override {
+        app_ = nil;
+        return true;
+    }
+
+private:
+    NSApplication* __strong app_ = nil;
+};
+
+class CocoaWindowHost final : public IWindowHost {
+public:
+    bool CreatePrimaryWindow(const WindowSpec& spec) override {
+        @autoreleasepool {
+            if (![NSThread isMainThread]) {
+                return false;
+            }
+
+            NSRect frame = NSMakeRect(0.0, 0.0, spec.width, spec.height);
+            NSWindowStyleMask style_mask = NSWindowStyleMaskTitled |
+                NSWindowStyleMaskClosable |
+                NSWindowStyleMaskMiniaturizable |
+                NSWindowStyleMaskResizable;
+
+            window_ = [[NSWindow alloc] initWithContentRect:frame
+                                                  styleMask:style_mask
+                                                    backing:NSBackingStoreBuffered
+                                                      defer:NO];
+            if (!window_) {
+                return false;
+            }
+
+            NSString* title = [NSString stringWithUTF8String:spec.title.c_str()];
+            if (title) {
+                [window_ setTitle:title];
+            }
+
+            if (spec.visible) {
+                [window_ makeKeyAndOrderFront:nil];
+            } else {
+                [window_ orderOut:nil];
+            }
+
+            return true;
+        }
+    }
+
+    bool PreRender() override {
+        return true;
+    }
+
+    bool Render() override {
+        return true;
+    }
+
+    bool PostRender() override {
+        return true;
+    }
+
+    bool TeardownWindows() override {
+        if (window_) {
+            [window_ orderOut:nil];
+            [window_ close];
+            window_ = nil;
+        }
+
+        return true;
+    }
+
+private:
+    NSWindow* __strong window_ = nil;
+};
+
+} // namespace
+
+bool CocoaBackendAvailable() {
+    return true;
+}
+
+std::shared_ptr<IPlatformHost> CreateCocoaPlatformHost() {
+    return std::make_shared<CocoaPlatformHost>();
+}
+
+std::shared_ptr<IWindowHost> CreateCocoaWindowHost() {
+    return std::make_shared<CocoaWindowHost>();
+}
+
+} // namespace framekit::runtime::detail

--- a/src/platform_backend_factory_internal.hpp
+++ b/src/platform_backend_factory_internal.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "framekit/platform/host_runtime.hpp"
+
+#include <memory>
+
+namespace framekit::runtime::detail {
+
+bool CocoaBackendAvailable();
+std::shared_ptr<IPlatformHost> CreateCocoaPlatformHost();
+std::shared_ptr<IWindowHost> CreateCocoaWindowHost();
+
+} // namespace framekit::runtime::detail

--- a/src/platform_backend_factory_stub.cpp
+++ b/src/platform_backend_factory_stub.cpp
@@ -1,0 +1,17 @@
+#include "platform_backend_factory_internal.hpp"
+
+namespace framekit::runtime::detail {
+
+bool CocoaBackendAvailable() {
+    return false;
+}
+
+std::shared_ptr<IPlatformHost> CreateCocoaPlatformHost() {
+    return {};
+}
+
+std::shared_ptr<IWindowHost> CreateCocoaWindowHost() {
+    return {};
+}
+
+} // namespace framekit::runtime::detail

--- a/src/platform_host_runtime.cpp
+++ b/src/platform_host_runtime.cpp
@@ -1,8 +1,21 @@
 #include "framekit/platform/host_runtime.hpp"
+#include "platform_backend_factory_internal.hpp"
 
 #include <algorithm>
 
 namespace framekit::runtime {
+
+namespace {
+
+bool EligibleForCocoaAutoWire(const LoopPolicy& policy, bool has_render_stages) {
+    if (!has_render_stages) {
+        return false;
+    }
+
+    return policy.profile == LoopProfile::kGui || policy.profile == LoopProfile::kHybrid;
+}
+
+} // namespace
 
 void PlatformHostRuntime::SetPlatformHost(std::shared_ptr<IPlatformHost> host) {
     platform_host_ = std::move(host);
@@ -183,6 +196,18 @@ bool PlatformHostRuntime::Start() {
         return false;
     }
 
+    const bool has_render_stages = HasActiveRenderStages();
+    const bool can_auto_wire_cocoa =
+        !platform_host_ &&
+        !window_host_ &&
+        EligibleForCocoaAutoWire(policy_, has_render_stages) &&
+        detail::CocoaBackendAvailable();
+
+    if (can_auto_wire_cocoa) {
+        platform_host_ = detail::CreateCocoaPlatformHost();
+        window_host_ = detail::CreateCocoaWindowHost();
+    }
+
     if (!platform_host_) {
         last_error_ = "platform host is required";
         return false;
@@ -193,7 +218,7 @@ bool PlatformHostRuntime::Start() {
         return false;
     }
 
-    if (HasActiveRenderStages()) {
+    if (has_render_stages) {
         if (!window_host_) {
             last_error_ = "window host is required when render stages are active";
             return false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,15 @@ add_executable(framekit_platform_host_runtime_test
 target_link_libraries(framekit_platform_host_runtime_test PRIVATE FrameKit::Core)
 add_test(NAME framekit_platform_host_runtime_test COMMAND framekit_platform_host_runtime_test)
 
+if(APPLE AND FRAMEKIT_ENABLE_COCOA)
+    add_executable(framekit_platform_host_runtime_cocoa_test
+        test_platform_host_runtime_cocoa.cpp
+    )
+
+    target_link_libraries(framekit_platform_host_runtime_cocoa_test PRIVATE FrameKit::Core)
+    add_test(NAME framekit_platform_host_runtime_cocoa_test COMMAND framekit_platform_host_runtime_cocoa_test)
+endif()
+
 add_executable(framekit_input_routing_runtime_test
     test_input_routing_runtime.cpp
 )

--- a/tests/test_platform_host_runtime_cocoa.cpp
+++ b/tests/test_platform_host_runtime_cocoa.cpp
@@ -1,0 +1,165 @@
+#include "framekit/framekit.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace {
+
+[[noreturn]] void FailRequirement(const char* expr, int line) {
+    std::cerr << "Requirement failed at line " << line << ": " << expr << '\n';
+    std::abort();
+}
+
+#define REQUIRE(expr)            \
+    do {                         \
+        if (!(expr)) {           \
+            FailRequirement(#expr, __LINE__); \
+        }                        \
+    } while (false)
+
+class FakePlatformHost : public framekit::runtime::IPlatformHost {
+public:
+    bool Initialize() override {
+        initialize_calls += 1;
+        return true;
+    }
+
+    bool PumpEvents() override {
+        pump_calls += 1;
+        return true;
+    }
+
+    bool Teardown() override {
+        teardown_calls += 1;
+        return true;
+    }
+
+    int initialize_calls = 0;
+    int pump_calls = 0;
+    int teardown_calls = 0;
+};
+
+class FakeWindowHost : public framekit::runtime::IWindowHost {
+public:
+    bool CreatePrimaryWindow(const framekit::runtime::WindowSpec& spec) override {
+        create_calls += 1;
+        last_title = spec.title;
+        last_visible = spec.visible;
+        return true;
+    }
+
+    bool PreRender() override {
+        pre_render_calls += 1;
+        return true;
+    }
+
+    bool Render() override {
+        render_calls += 1;
+        return true;
+    }
+
+    bool PostRender() override {
+        post_render_calls += 1;
+        return true;
+    }
+
+    bool TeardownWindows() override {
+        teardown_calls += 1;
+        return true;
+    }
+
+    int create_calls = 0;
+    int pre_render_calls = 0;
+    int render_calls = 0;
+    int post_render_calls = 0;
+    int teardown_calls = 0;
+    std::string last_title;
+    bool last_visible = true;
+};
+
+framekit::runtime::LoopPolicy GuiPolicy() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kGui;
+    policy.rendering_enabled = true;
+    return policy;
+}
+
+framekit::runtime::LoopPolicy HybridPolicy() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kHybrid;
+    policy.rendering_enabled = true;
+    return policy;
+}
+
+framekit::runtime::WindowSpec HiddenWindowSpec(std::string title) {
+    framekit::runtime::WindowSpec spec;
+    spec.title = title;
+    spec.visible = false;
+    spec.width = 640;
+    spec.height = 480;
+    return spec;
+}
+
+void TestGuiRuntimeAutoWiresCocoaBackend() {
+    framekit::runtime::PlatformHostRuntime runtime;
+
+    REQUIRE(runtime.Configure(GuiPolicy(), HiddenWindowSpec("framekit-cocoa-gui")));
+    REQUIRE(runtime.Start());
+    REQUIRE(runtime.Tick());
+    REQUIRE(runtime.Stop());
+}
+
+void TestHybridRuntimeAutoWiresCocoaBackend() {
+    framekit::runtime::PlatformHostRuntime runtime;
+
+    REQUIRE(runtime.Configure(HybridPolicy(), HiddenWindowSpec("framekit-cocoa-hybrid")));
+    REQUIRE(runtime.Start());
+    REQUIRE(runtime.Tick());
+    REQUIRE(runtime.Stop());
+}
+
+void TestPartialManualInjectionStillFails() {
+    framekit::runtime::PlatformHostRuntime runtime;
+    runtime.SetPlatformHost(std::make_shared<FakePlatformHost>());
+
+    REQUIRE(runtime.Configure(GuiPolicy(), HiddenWindowSpec("framekit-cocoa-partial")));
+    REQUIRE(!runtime.Start());
+    REQUIRE(runtime.LastError() == "window host is required when render stages are active");
+}
+
+void TestExplicitInjectedHostsStillWin() {
+    auto platform = std::make_shared<FakePlatformHost>();
+    auto window = std::make_shared<FakeWindowHost>();
+
+    framekit::runtime::PlatformHostRuntime runtime;
+    runtime.SetPlatformHost(platform);
+    runtime.SetWindowHost(window);
+
+    REQUIRE(runtime.Configure(GuiPolicy(), HiddenWindowSpec("framekit-manual-hosts")));
+    REQUIRE(runtime.Start());
+    REQUIRE(runtime.Tick());
+    REQUIRE(runtime.Stop());
+
+    REQUIRE(platform->initialize_calls == 1);
+    REQUIRE(platform->pump_calls == 1);
+    REQUIRE(platform->teardown_calls == 1);
+    REQUIRE(window->create_calls == 1);
+    REQUIRE(window->pre_render_calls == 1);
+    REQUIRE(window->render_calls == 1);
+    REQUIRE(window->post_render_calls == 1);
+    REQUIRE(window->teardown_calls == 1);
+    REQUIRE(window->last_title == "framekit-manual-hosts");
+    REQUIRE(!window->last_visible);
+}
+
+} // namespace
+
+int main() {
+    TestGuiRuntimeAutoWiresCocoaBackend();
+    TestHybridRuntimeAutoWiresCocoaBackend();
+    TestPartialManualInjectionStillFails();
+    TestExplicitInjectedHostsStillWin();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add an experimental `FRAMEKIT_ENABLE_COCOA` build path for macOS
- add internal Cocoa-backed platform/window host implementations and auto-wire them from `PlatformHostRuntime` for eligible GUI/Hybrid render-active usage when no hosts are injected
- add Apple-gated runtime tests for Cocoa auto-wiring and update README language to describe Cocoa support as experimental/local-only

## Validation
- `cmake -S . -B build-verify-no-cocoa -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_COCOA=OFF`
- `cmake --build build-verify-no-cocoa -j4`
- `ctest --test-dir build-verify-no-cocoa --output-on-failure`
- `cmake -S . -B build-verify-cocoa -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=OFF -DFRAMEKIT_ENABLE_COCOA=ON`
- `cmake --build build-verify-cocoa -j4`
- `ctest --test-dir build-verify-cocoa --output-on-failure`

Refs #119
