### PR TITLE
fix(core): harden service teardown and module id validation (#121)

### DIFF
--- a/include/framekit/module/graph.hpp
+++ b/include/framekit/module/graph.hpp
@@ -19,6 +19,7 @@ enum class ModuleGraphErrorCode : std::uint8_t {
     kCycleDetected = 3,
     kSelfDependency = 4,
     kDuplicateDependencyEntry = 5,
+    kInvalidModuleId = 6,
 };
 
 struct ModuleGraphError {

--- a/include/framekit/service/context.hpp
+++ b/include/framekit/service/context.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <stdexcept>
 #include <string>
 #include <typeindex>
 #include <unordered_map>
@@ -67,10 +69,12 @@ public:
         };
 
         std::vector<OrderedEntry> ordered;
+        std::unordered_map<ServiceKey, ServiceEntry, ServiceKeyHasher> external_entries;
         ordered.reserve(entries_.size());
 
         for (const auto& [service_key, entry] : entries_) {
             if (entry.ownership != ServiceOwnership::kContextOwned) {
+                external_entries.emplace(service_key, entry);
                 continue;
             }
 
@@ -98,7 +102,7 @@ public:
             });
         }
 
-        entries_.clear();
+        entries_ = std::move(external_entries);
         return true;
     }
 
@@ -124,7 +128,8 @@ public:
         return entries_.size();
     }
 
-    const std::vector<ServiceTeardownRecord>& LastTeardownOrder() const {
+    std::vector<ServiceTeardownRecord> LastTeardownOrder() const {
+        std::shared_lock lock(mutex_);
         return last_teardown_order_;
     }
 

--- a/src/module_graph.cpp
+++ b/src/module_graph.cpp
@@ -26,7 +26,7 @@ ModuleGraphValidationResult ValidateModuleGraph(const std::vector<ModuleSpec>& m
     for (const auto& module : modules) {
         if (module.id.empty()) {
             return Invalid(ModuleGraphError{
-                .code = ModuleGraphErrorCode::kDuplicateModuleId,
+                .code = ModuleGraphErrorCode::kInvalidModuleId,
                 .module_id = module.id,
                 .dependency_id = {},
                 .message = "module id must be non-empty",

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -125,13 +125,15 @@ void TestServiceContext() {
     REQUIRE(services.BeginTeardown());
     REQUIRE(services.Phase() == framekit::runtime::ServiceContextPhase::kTeardown);
     REQUIRE(services.Find<TestService>() == nullptr);
+    REQUIRE(services.ServiceCount() == 1);
 
-    const auto& order = services.LastTeardownOrder();
+    const auto order = services.LastTeardownOrder();
     REQUIRE(order.size() == 1);
     REQUIRE(order.front().contract_type == std::type_index(typeid(TestService)));
 
     REQUIRE(services.ResetForNextStartCycle());
     REQUIRE(services.Phase() == framekit::runtime::ServiceContextPhase::kOpen);
+    REQUIRE(services.ServiceCount() == 0);
 }
 
 void TestModuleGraphValidation() {
@@ -194,6 +196,19 @@ void TestModuleGraphValidation() {
     REQUIRE(!missing_result.valid);
     REQUIRE(!missing_result.errors.empty());
     REQUIRE(missing_result.errors.front().code == framekit::runtime::ModuleGraphErrorCode::kMissingRequiredDependency);
+
+    const std::vector<framekit::runtime::ModuleSpec> invalid_module_id = {
+        framekit::runtime::ModuleSpec{
+            .id = "",
+            .required_dependencies = {},
+            .optional_dependencies = {},
+        },
+    };
+
+    const auto invalid_id_result = framekit::runtime::ValidateModuleGraph(invalid_module_id);
+    REQUIRE(!invalid_id_result.valid);
+    REQUIRE(!invalid_id_result.errors.empty());
+    REQUIRE(invalid_id_result.errors.front().code == framekit::runtime::ModuleGraphErrorCode::kInvalidModuleId);
 }
 
 void TestEventBusSemantics() {


### PR DESCRIPTION
Summary:\n- add missing self-sufficient includes to ServiceContext header\n- make LastTeardownOrder return a synchronized snapshot\n- preserve external-owned service entries during BeginTeardown while keeping deterministic context-owned teardown order\n- classify empty module ids with dedicated invalid-id error code\n- extend runtime primitive tests for new teardown and module-id semantics\n\nValidation:\n- cmake --build build -j4\n- ctest --test-dir build --output-on-failure\n\nCloses #121