### PR TITLE
fix(service): enforce non-owning external service semantics (#123)

### DIFF
--- a/include/framekit/service/context.hpp
+++ b/include/framekit/service/context.hpp
@@ -161,11 +161,18 @@ public:
             sequence = existing->second.sequence;
         }
 
-        entries_[std::move(service_key)] = ServiceEntry{
-            .instance = std::static_pointer_cast<void>(std::move(service)),
+        auto storage = ServiceEntry{
             .ownership = ownership,
             .sequence = sequence,
         };
+
+        if (ownership == ServiceOwnership::kExternalOwned) {
+            storage.external_instance = std::static_pointer_cast<void>(service);
+        } else {
+            storage.instance = std::static_pointer_cast<void>(std::move(service));
+        }
+
+        entries_[std::move(service_key)] = std::move(storage);
 
         return true;
     }
@@ -181,6 +188,10 @@ public:
         const auto found = entries_.find(service_key);
         if (found == entries_.end()) {
             return nullptr;
+        }
+
+        if (found->second.ownership == ServiceOwnership::kExternalOwned) {
+            return std::static_pointer_cast<T>(found->second.external_instance.lock());
         }
 
         return std::static_pointer_cast<T>(found->second.instance);
@@ -215,6 +226,7 @@ private:
 
     struct ServiceEntry {
         std::shared_ptr<void> instance;
+        std::weak_ptr<void> external_instance;
         ServiceOwnership ownership = ServiceOwnership::kContextOwned;
         std::size_t sequence = 0;
     };

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -104,8 +104,9 @@ void TestServiceContext() {
 
     REQUIRE(services.Register<TestService>(test_service));
     REQUIRE(!services.Register<TestService>(std::make_shared<TestService>()));
+    auto external_alt = std::make_shared<AlternateService>(AlternateService{"alt"});
     REQUIRE(services.Register<AlternateService>(
-        std::make_shared<AlternateService>(AlternateService{"alt"}),
+        external_alt,
         "alt",
         framekit::runtime::ServiceOwnership::kExternalOwned));
 
@@ -121,6 +122,10 @@ void TestServiceContext() {
     auto alt = services.Find<AlternateService>("alt");
     REQUIRE(alt != nullptr);
     REQUIRE(alt->name == "alt");
+
+    alt.reset();
+    external_alt.reset();
+    REQUIRE(services.Find<AlternateService>("alt") == nullptr);
 
     REQUIRE(services.BeginTeardown());
     REQUIRE(services.Phase() == framekit::runtime::ServiceContextPhase::kTeardown);


### PR DESCRIPTION
Summary:\n- store ServiceOwnership::kExternalOwned registrations as weak references in ServiceContext\n- resolve external-owned lookups via weak lock so context does not keep them alive\n- keep context-owned teardown ordering behavior unchanged\n- add primitive test coverage for external-owned lifetime expiration behavior\n\nValidation:\n- cmake --build build -j4\n- ctest --test-dir build --output-on-failure\n\nCloses #123