### PR TITLE
ci(platform): enable Cocoa validation and macOS launch checks

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -51,13 +51,18 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure
-        run: cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF -DCMAKE_BUILD_TYPE=Release
+        run: cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF -DFRAMEKIT_ENABLE_COCOA=ON -DCMAKE_BUILD_TYPE=Release
 
       - name: Build
         run: cmake --build build
 
       - name: Test
         run: ctest --test-dir build --output-on-failure
+
+      - name: Launch examples (macOS)
+        run: |
+          ./build/framekit_single_process_example
+          ./build/framekit_multi_worker_example
 
   framekit-with-netkit:
     name: netkit-shmpipe
@@ -97,7 +102,7 @@ jobs:
           path: netkit
 
       - name: Configure
-        run: cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=ON -DFRAMEKIT_NETKIT_SOURCE_DIR=${{ github.workspace }}/netkit -DCMAKE_BUILD_TYPE=Release
+        run: cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=ON -DFRAMEKIT_ENABLE_COCOA=ON -DFRAMEKIT_NETKIT_SOURCE_DIR=${{ github.workspace }}/netkit -DCMAKE_BUILD_TYPE=Release
 
       - name: Build
         run: cmake --build build

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -17,6 +17,11 @@ Current baseline includes:
 - event bus immediate/deferred dispatch baseline with consume and priority semantics
 - selective-linking guidance for optional module usage
 
+Platform validation coverage includes:
+- Linux and macOS CMake build + contract test coverage in CI
+- macOS Cocoa backend validation in CI with `FRAMEKIT_ENABLE_COCOA=ON`
+- deterministic macOS launch checks for `framekit_single_process_example` and `framekit_multi_worker_example`
+
 Public include layout is organized by concern under `include/framekit/`:
 - `spec/`, `lifecycle/`, `loop/`, `platform/`, `input/`, `event/`, `module/`, `service/`, `fault/`, `kernel/`, `multiprocess/`, and `ipc/`
 


### PR DESCRIPTION
## Summary
- enable `FRAMEKIT_ENABLE_COCOA=ON` in macOS CI jobs so Cocoa backend/runtime coverage is exercised
- add explicit macOS example launch validation for `framekit_single_process_example` and `framekit_multi_worker_example`
- document macOS Cocoa validation coverage in the overview

## Validation
- `cmake -S framekit -B framekit/build-issue126 -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF -DFRAMEKIT_ENABLE_COCOA=ON -DCMAKE_BUILD_TYPE=Release`
- `cmake --build framekit/build-issue126`
- `ctest --test-dir framekit/build-issue126 --output-on-failure`
- `framekit/build-issue126/framekit_single_process_example`
- `framekit/build-issue126/framekit_multi_worker_example`

Closes #126
