### PR TITLE
test(platform): codify launch validation in CTest and add support matrix

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -57,12 +57,10 @@ jobs:
         run: cmake --build build
 
       - name: Test
-        run: ctest --test-dir build --output-on-failure
+        run: ctest --test-dir build --output-on-failure -LE example-launch
 
       - name: Launch examples (macOS)
-        run: |
-          ./build/framekit_single_process_example
-          ./build/framekit_multi_worker_example
+        run: ctest --test-dir build --output-on-failure -L example-launch
 
   framekit-with-netkit:
     name: netkit-shmpipe
@@ -85,7 +83,10 @@ jobs:
         run: cmake --build build
 
       - name: Test
-        run: ctest --test-dir build --output-on-failure
+        run: ctest --test-dir build --output-on-failure -LE example-launch
+
+      - name: Launch examples (macOS)
+        run: ctest --test-dir build --output-on-failure -L example-launch
 
   framekit-with-netkit-macos:
     name: netkit-shmpipe-macos

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,10 @@ if(FRAMEKIT_ENABLE_COCOA)
     )
 endif()
 
+if(FRAMEKIT_BUILD_TESTS)
+    enable_testing()
+endif()
+
 if(FRAMEKIT_BUILD_EXAMPLES)
     add_executable(framekit_single_process_example
         examples/single_process/main.cpp
@@ -71,6 +75,20 @@ if(FRAMEKIT_BUILD_EXAMPLES)
         examples/multi_worker/main.cpp
     )
     target_link_libraries(framekit_multi_worker_example PRIVATE FrameKit::Core)
+
+    if(FRAMEKIT_BUILD_TESTS AND APPLE AND FRAMEKIT_ENABLE_COCOA)
+        add_test(NAME framekit_example_launch_single_process
+            COMMAND framekit_single_process_example
+        )
+        add_test(NAME framekit_example_launch_multi_worker
+            COMMAND framekit_multi_worker_example
+        )
+        set_tests_properties(
+            framekit_example_launch_single_process
+            framekit_example_launch_multi_worker
+            PROPERTIES LABELS "example-launch;platform;cocoa"
+        )
+    endif()
 endif()
 
 if(FRAMEKIT_ENABLE_NETKIT)
@@ -99,6 +117,5 @@ if(FRAMEKIT_ENABLE_NETKIT)
 endif()
 
 if(FRAMEKIT_BUILD_TESTS)
-    enable_testing()
     add_subdirectory(tests)
 endif()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,7 @@
 - [FrameKit v2 Charter](charter-v2.md)
 - [External Integration Boundary Contract](integration-boundary.md)
 - [FrameKit v2 Stable Contract Inventory](v2-stable-contracts.md)
+- [Platform Support Matrix](platform-support-matrix.md)
 - [Lifecycle and Shutdown Semantics](lifecycle-semantics.md)
 - [Loop Stage Graph and Profile/Policy Specification](loop-stage-graph-profiles.md)
 - [Module Contract and Dependency DAG Semantics](module-contract-dag-semantics.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -26,5 +26,6 @@ Public include layout is organized by concern under `include/framekit/`:
 - `spec/`, `lifecycle/`, `loop/`, `platform/`, `input/`, `event/`, `module/`, `service/`, `fault/`, `kernel/`, `multiprocess/`, and `ipc/`
 
 For v2 scope and boundaries, see the [FrameKit v2 Charter](charter-v2.md).
+For platform support and validation pathways, see the [Platform Support Matrix](platform-support-matrix.md).
 For latest contract-drift evidence and remediation traceability, see the [API/Docs Contract Alignment Audit (2026-03-29)](doctrine/api-doc-contract-alignment-2026-03-29.md).
 For the sequenced post-release backlog after `v2.0.0`, see the [Post-Release Roadmap (2026-03-29)](doctrine/post-release-roadmap-2026-03-29.md).

--- a/docs/platform-support-matrix.md
+++ b/docs/platform-support-matrix.md
@@ -1,0 +1,25 @@
+# Platform Support Matrix
+
+This matrix documents the currently supported host targets and the validation paths that gate changes.
+
+## Runtime/Backend Matrix
+
+| Host platform | Platform backend path | Status | Primary validation path |
+| --- | --- | --- | --- |
+| Linux | Stub/manual host injection (`platform_backend_factory_stub.cpp`) | Supported | `CI (C++ / CMake)` Linux jobs: configure, build, and contract tests |
+| macOS | Cocoa backend (`cocoa_platform_backend.mm`) with `FRAMEKIT_ENABLE_COCOA=ON` | Supported | `CI (C++ / CMake)` macOS jobs: configure/build, contract tests, and `example-launch` CTest checks |
+
+## Validation Notes
+
+- Cocoa backend support is opt-in via `FRAMEKIT_ENABLE_COCOA=ON`.
+- Example runtime launch checks are codified as CTest cases:
+  - `framekit_example_launch_single_process`
+  - `framekit_example_launch_multi_worker`
+- macOS CI executes launch validation through CTest labels:
+  - contract/runtime suite: `ctest --test-dir build --output-on-failure -LE example-launch`
+  - launch checks: `ctest --test-dir build --output-on-failure -L example-launch`
+
+## Scope Boundaries
+
+- This matrix describes FrameKit host/runtime validation only.
+- Optional NetKit/MediaKit integrations remain composition-level and are tracked separately from host backend support.


### PR DESCRIPTION
Summary:\n- add CTest-based launch checks for framekit core examples when Cocoa validation is enabled\n- update macOS CI jobs to run launch checks through CTest labels instead of direct executable calls\n- add and link a platform support matrix document covering host backend and validation paths\n\nValidation:\n- cmake -S framekit -B framekit/build-issue128 -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF -DFRAMEKIT_ENABLE_COCOA=ON -DCMAKE_BUILD_TYPE=Release\n- cmake --build framekit/build-issue128\n- ctest --test-dir framekit/build-issue128 --output-on-failure -LE example-launch\n- ctest --test-dir framekit/build-issue128 --output-on-failure -L example-launch\n\nCloses #128