### PR TITLE
docs(integration): add composition matrix and bridge patterns

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,7 @@
 - [External Integration Boundary Contract](integration-boundary.md)
 - [FrameKit v2 Stable Contract Inventory](v2-stable-contracts.md)
 - [Platform Support Matrix](platform-support-matrix.md)
+- [Composition Matrix](composition-matrix.md)
 - [Lifecycle and Shutdown Semantics](lifecycle-semantics.md)
 - [Loop Stage Graph and Profile/Policy Specification](loop-stage-graph-profiles.md)
 - [Module Contract and Dependency DAG Semantics](module-contract-dag-semantics.md)

--- a/docs/composition-matrix.md
+++ b/docs/composition-matrix.md
@@ -1,0 +1,63 @@
+# Composition Matrix
+
+Status: Stable
+Last Reviewed: 2026-03-30
+
+## Purpose
+
+Define the supported composition modes for integrating FrameKit with optional
+runtime dependencies while preserving the external integration boundary.
+
+## Composition Modes
+
+| Mode | Build options | Example binaries | Primary use |
+| --- | --- | --- | --- |
+| Single-process host | `FRAMEKIT_ENABLE_NETKIT=OFF` | `framekit_single_process_example` | Local deterministic host lifecycle with no external transport dependency |
+| Multiprocess host (local launcher) | `FRAMEKIT_ENABLE_NETKIT=OFF` | `framekit_multi_worker_example` | Parent + worker topology and liveness semantics without external IPC runtime |
+| Multiprocess host + transport-backed integration | `FRAMEKIT_ENABLE_NETKIT=ON` and `FRAMEKIT_NETKIT_SOURCE_DIR=<path>` | `framekit_frontend_example`, `framekit_backend_example` | Composition boundary where FrameKit host contracts coordinate with NetKit transport adapters |
+
+## Bridge Module Patterns
+
+Bridge modules live in composition applications, not FrameKit core and not
+external runtime repositories.
+
+### 1) Lifecycle Bridge
+
+- Convert app startup intent into `ApplicationSpec` and runtime configuration.
+- Own startup/shutdown ordering for FrameKit host and external runtime startup.
+- Keep fallback and retry behavior in composition code rather than FrameKit.
+
+### 2) Service Bridge
+
+- Register integration-facing services in scoped service context.
+- Expose minimal host-facing interfaces rather than runtime concrete types.
+- Teardown external resources through composition-owned shutdown hooks.
+
+### 3) Event Bridge
+
+- Translate runtime-native events into FrameKit event bus payloads.
+- Keep domain payload schemas and event typing outside FrameKit contracts.
+- Map subscription boundaries in composition modules only.
+
+### 4) Transport Bridge
+
+- Select transport kind through application configuration.
+- Bind runtime transport factories and endpoint naming in composition wiring.
+- Keep transport-specific diagnostics and adaptation logic outside FrameKit core.
+
+## Validation Expectations
+
+- Core composition paths validate with FrameKit CI build/test coverage.
+- Cocoa-enabled macOS paths validate launch checks through CTest `example-launch`
+  labels.
+- NetKit-backed examples validate by enabling NetKit and building/running the
+  frontend/backend examples.
+
+## Boundary Alignment
+
+This matrix is constrained by the
+[External Integration Boundary Contract](integration-boundary.md):
+
+- FrameKit remains domain-agnostic.
+- External runtime repositories remain FrameKit-independent.
+- Composition behavior is implemented only in integration applications.

--- a/docs/integration-boundary.md
+++ b/docs/integration-boundary.md
@@ -60,3 +60,7 @@ repositories remain FrameKit-independent.
 
 NodeX is an example domain runtime system used to validate this boundary.
 The same separation rules apply to any external runtime.
+
+Companion integration guidance:
+
+- [Composition Matrix](composition-matrix.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -27,5 +27,6 @@ Public include layout is organized by concern under `include/framekit/`:
 
 For v2 scope and boundaries, see the [FrameKit v2 Charter](charter-v2.md).
 For platform support and validation pathways, see the [Platform Support Matrix](platform-support-matrix.md).
+For integration composition modes and bridge-module patterns, see the [Composition Matrix](composition-matrix.md).
 For latest contract-drift evidence and remediation traceability, see the [API/Docs Contract Alignment Audit (2026-03-29)](doctrine/api-doc-contract-alignment-2026-03-29.md).
 For the sequenced post-release backlog after `v2.0.0`, see the [Post-Release Roadmap (2026-03-29)](doctrine/post-release-roadmap-2026-03-29.md).

--- a/docs/selective_linking.md
+++ b/docs/selective_linking.md
@@ -1,6 +1,8 @@
 # Selective Linking Guide
 
 FrameKit supports optional linkage. You only link modules you explicitly enable.
+For composition-mode mapping and bridge responsibilities, see the
+[Composition Matrix](composition-matrix.md).
 
 ## 1) FrameKit core only (no NetKit)
 ```bash
@@ -32,3 +34,15 @@ Check linked libraries of your app:
 - Windows: `dumpbin /dependents <binary>`
 
 If NetKit is disabled, your FrameKit binaries should not link NetKit artifacts.
+
+## Composition Validation Paths
+
+- Single-process host validation:
+  - build with `FRAMEKIT_ENABLE_NETKIT=OFF`
+  - run `framekit_single_process_example`
+- Multiprocess host validation:
+  - build with `FRAMEKIT_ENABLE_NETKIT=OFF`
+  - run `framekit_multi_worker_example`
+- Transport-backed integration validation:
+  - build with `FRAMEKIT_ENABLE_NETKIT=ON`
+  - run `framekit_frontend_example` and `framekit_backend_example`


### PR DESCRIPTION
Summary:\n- add docs/composition-matrix.md defining supported composition modes\n- document bridge-module patterns for lifecycle, services, events, and transport handoff\n- link composition guidance from overview, architecture, integration-boundary, and selective-linking docs\n\nValidation:\n- docs consistency checked via workspace diagnostics\n\nCloses #131