### PR TITLE
test(integration): add netkit example CTest validation hooks

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -83,10 +83,10 @@ jobs:
         run: cmake --build build
 
       - name: Test
-        run: ctest --test-dir build --output-on-failure -LE example-launch
+        run: ctest --test-dir build --output-on-failure -LE integration-example
 
-      - name: Launch examples (macOS)
-        run: ctest --test-dir build --output-on-failure -L example-launch
+      - name: Launch integration examples
+        run: ctest --test-dir build --output-on-failure -L integration-example
 
   framekit-with-netkit-macos:
     name: netkit-shmpipe-macos
@@ -109,7 +109,10 @@ jobs:
         run: cmake --build build
 
       - name: Test
-        run: ctest --test-dir build --output-on-failure
+        run: ctest --test-dir build --output-on-failure -LE example-launch
+
+      - name: Launch examples (macOS)
+        run: ctest --test-dir build --output-on-failure -L integration-example
 
   sanitizer-linux:
     name: sanitizer-linux-clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,20 @@ if(FRAMEKIT_ENABLE_NETKIT)
             examples/frontend_backend/backend_main.cpp
         )
         target_link_libraries(framekit_backend_example PRIVATE FrameKit::Core NetKit::Transport)
+
+        if(FRAMEKIT_BUILD_TESTS)
+            add_test(NAME framekit_example_launch_frontend
+                COMMAND framekit_frontend_example
+            )
+            add_test(NAME framekit_example_launch_backend
+                COMMAND framekit_backend_example
+            )
+            set_tests_properties(
+                framekit_example_launch_frontend
+                framekit_example_launch_backend
+                PROPERTIES LABELS "integration-example;example-launch;integration;netkit"
+            )
+        endif()
     elseif(FRAMEKIT_BUILD_EXAMPLES)
         message(WARNING "FRAMEKIT_ENABLE_NETKIT=ON but NetKit::Transport was not found; skipping netkit examples")
     endif()

--- a/docs/composition-matrix.md
+++ b/docs/composition-matrix.md
@@ -50,8 +50,8 @@ external runtime repositories.
 - Core composition paths validate with FrameKit CI build/test coverage.
 - Cocoa-enabled macOS paths validate launch checks through CTest `example-launch`
   labels.
-- NetKit-backed examples validate by enabling NetKit and building/running the
-  frontend/backend examples.
+- NetKit-backed examples validate through CTest `integration-example` labels in
+  NetKit-enabled CI jobs.
 
 ## Boundary Alignment
 

--- a/docs/selective_linking.md
+++ b/docs/selective_linking.md
@@ -45,4 +45,4 @@ If NetKit is disabled, your FrameKit binaries should not link NetKit artifacts.
   - run `framekit_multi_worker_example`
 - Transport-backed integration validation:
   - build with `FRAMEKIT_ENABLE_NETKIT=ON`
-  - run `framekit_frontend_example` and `framekit_backend_example`
+  - run `ctest --test-dir build --output-on-failure -L integration-example`


### PR DESCRIPTION
Summary:\n- register NetKit frontend/backend examples as labeled CTest launch checks\n- update netkit CI jobs to run integration-example checks via CTest labels\n- align integration docs with the CTest-based validation path\n\nValidation:\n- cmake -S framekit -B framekit/build-issue133 -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=ON -DFRAMEKIT_NETKIT_SOURCE_DIR=netkit -DCMAKE_BUILD_TYPE=Release\n- cmake --build framekit/build-issue133\n- ctest --test-dir framekit/build-issue133 --output-on-failure -LE integration-example\n- ctest --test-dir framekit/build-issue133 --output-on-failure -L integration-example\n- cmake -S framekit -B framekit/build-issue133-macos -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=ON -DFRAMEKIT_ENABLE_COCOA=ON -DFRAMEKIT_NETKIT_SOURCE_DIR=netkit -DCMAKE_BUILD_TYPE=Release\n- ctest --test-dir framekit/build-issue133-macos --output-on-failure -LE example-launch\n- ctest --test-dir framekit/build-issue133-macos --output-on-failure -L integration-example\n\nCloses #133