### PR TITLE
feat(core): add execution service registry contract

### DIFF
--- a/include/framekit/framekit.hpp
+++ b/include/framekit/framekit.hpp
@@ -33,6 +33,7 @@
 
 // Services and module graph.
 #include "framekit/service/context.hpp"
+#include "framekit/service/execution.hpp"
 #include "framekit/service/bootstrap.hpp"
 #include "framekit/module/graph.hpp"
 

--- a/include/framekit/service/execution.hpp
+++ b/include/framekit/service/execution.hpp
@@ -1,0 +1,231 @@
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace framekit::runtime {
+
+enum class ExecutionServicePhase : std::uint8_t {
+    kOpen = 0,
+    kFrozen = 1,
+    kShuttingDown = 2,
+};
+
+enum class ExecutionServiceOwnership : std::uint8_t {
+    kContextOwned = 0,
+    kExternalOwned = 1,
+};
+
+struct ExecutionServiceShutdownRecord {
+    std::string key;
+    ExecutionServiceOwnership ownership = ExecutionServiceOwnership::kContextOwned;
+};
+
+class IExecutionService {
+public:
+    virtual ~IExecutionService() = default;
+
+    virtual bool Submit(std::function<void()> task) = 0;
+    virtual bool BeginShutdown() = 0;
+    virtual bool AwaitShutdown(std::chrono::milliseconds timeout) = 0;
+};
+
+class ExecutionServiceRegistry {
+public:
+    ExecutionServiceRegistry() = default;
+
+    ExecutionServicePhase Phase() const {
+        std::shared_lock lock(mutex_);
+        return phase_;
+    }
+
+    bool Freeze() {
+        std::unique_lock lock(mutex_);
+        if (phase_ != ExecutionServicePhase::kOpen) {
+            return false;
+        }
+
+        phase_ = ExecutionServicePhase::kFrozen;
+        freeze_count_ += 1;
+        return true;
+    }
+
+    std::uint64_t FreezeCount() const {
+        std::shared_lock lock(mutex_);
+        return freeze_count_;
+    }
+
+    bool Register(
+        std::shared_ptr<IExecutionService> service,
+        std::string key = {},
+        ExecutionServiceOwnership ownership = ExecutionServiceOwnership::kContextOwned,
+        bool replace_existing = false) {
+        if (!service) {
+            return false;
+        }
+
+        std::unique_lock lock(mutex_);
+        if (phase_ != ExecutionServicePhase::kOpen) {
+            return false;
+        }
+
+        const auto found = entries_.find(key);
+        if (found != entries_.end() && !replace_existing) {
+            return false;
+        }
+
+        std::size_t sequence = registration_sequence_;
+        if (found == entries_.end()) {
+            registration_sequence_ += 1;
+        } else {
+            sequence = found->second.sequence;
+        }
+
+        ServiceEntry entry;
+        entry.ownership = ownership;
+        entry.sequence = sequence;
+        if (ownership == ExecutionServiceOwnership::kExternalOwned) {
+            entry.external_instance = std::move(service);
+        } else {
+            entry.instance = std::move(service);
+        }
+
+        entries_[std::move(key)] = std::move(entry);
+        return true;
+    }
+
+    std::shared_ptr<IExecutionService> Find(std::string key = {}) const {
+        std::shared_lock lock(mutex_);
+        if (phase_ == ExecutionServicePhase::kShuttingDown) {
+            return nullptr;
+        }
+
+        const auto found = entries_.find(key);
+        if (found == entries_.end()) {
+            return nullptr;
+        }
+
+        if (found->second.ownership == ExecutionServiceOwnership::kExternalOwned) {
+            return found->second.external_instance.lock();
+        }
+
+        return found->second.instance;
+    }
+
+    bool BeginShutdown(std::chrono::milliseconds timeout = std::chrono::milliseconds{0}) {
+        std::vector<OrderedEntry> ordered;
+        std::unordered_map<std::string, ServiceEntry> external_entries;
+
+        {
+            std::unique_lock lock(mutex_);
+
+            if (phase_ == ExecutionServicePhase::kShuttingDown) {
+                return true;
+            }
+            if (phase_ != ExecutionServicePhase::kOpen && phase_ != ExecutionServicePhase::kFrozen) {
+                return false;
+            }
+
+            phase_ = ExecutionServicePhase::kShuttingDown;
+
+            ordered.reserve(entries_.size());
+            for (const auto& [key, entry] : entries_) {
+                if (entry.ownership != ExecutionServiceOwnership::kContextOwned) {
+                    external_entries.emplace(key, entry);
+                    continue;
+                }
+
+                ordered.push_back(OrderedEntry{
+                    .key = key,
+                    .instance = entry.instance,
+                    .ownership = entry.ownership,
+                    .sequence = entry.sequence,
+                });
+            }
+
+            std::sort(
+                ordered.begin(),
+                ordered.end(),
+                [](const OrderedEntry& left, const OrderedEntry& right) {
+                    return left.sequence > right.sequence;
+                });
+
+            last_shutdown_order_.clear();
+            for (const auto& item : ordered) {
+                last_shutdown_order_.push_back(ExecutionServiceShutdownRecord{
+                    .key = item.key,
+                    .ownership = item.ownership,
+                });
+            }
+
+            entries_ = external_entries;
+        }
+
+        bool ok = true;
+        for (const auto& item : ordered) {
+            if (!item.instance) {
+                ok = false;
+                continue;
+            }
+
+            ok = item.instance->BeginShutdown() && ok;
+            ok = item.instance->AwaitShutdown(timeout) && ok;
+        }
+
+        return ok;
+    }
+
+    bool ResetForNextStartCycle() {
+        std::unique_lock lock(mutex_);
+        if (phase_ == ExecutionServicePhase::kFrozen) {
+            return false;
+        }
+
+        phase_ = ExecutionServicePhase::kOpen;
+        entries_.clear();
+        registration_sequence_ = 0;
+        return true;
+    }
+
+    std::size_t ServiceCount() const {
+        std::shared_lock lock(mutex_);
+        return entries_.size();
+    }
+
+    std::vector<ExecutionServiceShutdownRecord> LastShutdownOrder() const {
+        std::shared_lock lock(mutex_);
+        return last_shutdown_order_;
+    }
+
+private:
+    struct ServiceEntry {
+        std::shared_ptr<IExecutionService> instance;
+        std::weak_ptr<IExecutionService> external_instance;
+        ExecutionServiceOwnership ownership = ExecutionServiceOwnership::kContextOwned;
+        std::size_t sequence = 0;
+    };
+
+    struct OrderedEntry {
+        std::string key;
+        std::shared_ptr<IExecutionService> instance;
+        ExecutionServiceOwnership ownership = ExecutionServiceOwnership::kContextOwned;
+        std::size_t sequence = 0;
+    };
+
+    mutable std::shared_mutex mutex_;
+    ExecutionServicePhase phase_ = ExecutionServicePhase::kOpen;
+    std::uint64_t freeze_count_ = 0;
+    std::size_t registration_sequence_ = 0;
+    std::unordered_map<std::string, ServiceEntry> entries_;
+    std::vector<ExecutionServiceShutdownRecord> last_shutdown_order_;
+};
+
+} // namespace framekit::runtime

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <any>
+#include <chrono>
 #include <cstdlib>
 #include <iostream>
 #include <memory>
@@ -28,6 +29,38 @@ struct TestService {
 
 struct AlternateService {
     std::string name;
+};
+
+class FakeExecutionService : public framekit::runtime::IExecutionService {
+public:
+    bool Submit(std::function<void()> task) override {
+        submit_calls += 1;
+        if (!accept_submit) {
+            return false;
+        }
+        if (task) {
+            task();
+        }
+        return true;
+    }
+
+    bool BeginShutdown() override {
+        begin_shutdown_calls += 1;
+        return begin_shutdown_result;
+    }
+
+    bool AwaitShutdown(std::chrono::milliseconds timeout) override {
+        (void)timeout;
+        await_shutdown_calls += 1;
+        return await_shutdown_result;
+    }
+
+    int submit_calls = 0;
+    int begin_shutdown_calls = 0;
+    int await_shutdown_calls = 0;
+    bool accept_submit = true;
+    bool begin_shutdown_result = true;
+    bool await_shutdown_result = true;
 };
 
 const char* ModuleLifecyclePhaseName(framekit::runtime::ModuleLifecyclePhase phase) {
@@ -139,6 +172,60 @@ void TestServiceContext() {
     REQUIRE(services.ResetForNextStartCycle());
     REQUIRE(services.Phase() == framekit::runtime::ServiceContextPhase::kOpen);
     REQUIRE(services.ServiceCount() == 0);
+}
+
+void TestExecutionServiceRegistry() {
+    framekit::runtime::ExecutionServiceRegistry registry;
+
+    auto first = std::make_shared<FakeExecutionService>();
+    auto second = std::make_shared<FakeExecutionService>();
+    auto external = std::make_shared<FakeExecutionService>();
+
+    REQUIRE(registry.Register(first, "first"));
+    REQUIRE(!registry.Register(std::make_shared<FakeExecutionService>(), "first"));
+    REQUIRE(registry.Register(second, "second"));
+    REQUIRE(registry.Register(
+        external,
+        "external",
+        framekit::runtime::ExecutionServiceOwnership::kExternalOwned));
+
+    REQUIRE(registry.Freeze());
+    REQUIRE(registry.Phase() == framekit::runtime::ExecutionServicePhase::kFrozen);
+    REQUIRE(registry.FreezeCount() == 1);
+    REQUIRE(!registry.Register(std::make_shared<FakeExecutionService>(), "late"));
+
+    auto found_first = registry.Find("first");
+    REQUIRE(found_first != nullptr);
+    auto found_external = registry.Find("external");
+    REQUIRE(found_external != nullptr);
+
+    found_external.reset();
+    external.reset();
+    REQUIRE(registry.Find("external") == nullptr);
+
+    REQUIRE(registry.BeginShutdown(std::chrono::milliseconds{0}));
+    REQUIRE(registry.Phase() == framekit::runtime::ExecutionServicePhase::kShuttingDown);
+    REQUIRE(registry.Find("first") == nullptr);
+    REQUIRE(first->begin_shutdown_calls == 1);
+    REQUIRE(first->await_shutdown_calls == 1);
+    REQUIRE(second->begin_shutdown_calls == 1);
+    REQUIRE(second->await_shutdown_calls == 1);
+    REQUIRE(registry.ServiceCount() == 1);
+
+    const auto shutdown_order = registry.LastShutdownOrder();
+    REQUIRE(shutdown_order.size() == 2);
+    REQUIRE(shutdown_order[0].key == "second");
+    REQUIRE(shutdown_order[1].key == "first");
+
+    REQUIRE(registry.ResetForNextStartCycle());
+    REQUIRE(registry.Phase() == framekit::runtime::ExecutionServicePhase::kOpen);
+    REQUIRE(registry.ServiceCount() == 0);
+
+    framekit::runtime::ExecutionServiceRegistry failure_registry;
+    auto failure_service = std::make_shared<FakeExecutionService>();
+    failure_service->await_shutdown_result = false;
+    REQUIRE(failure_registry.Register(failure_service, "failure"));
+    REQUIRE(!failure_registry.BeginShutdown(std::chrono::milliseconds{0}));
 }
 
 void TestModuleGraphValidation() {
@@ -473,6 +560,7 @@ int main() {
     TestLifecycleStateMachine();
     TestLoopPolicyValidation();
     TestServiceContext();
+    TestExecutionServiceRegistry();
     TestModuleGraphValidation();
     TestEventBusSemantics();
     TestKernelRuntime();


### PR DESCRIPTION
Summary:\n- add a new execution service contract surface under include/framekit/service/execution.hpp\n- introduce an additive ExecutionServiceRegistry with ownership, freeze, and deterministic shutdown ordering semantics\n- expose the contract via include/framekit/framekit.hpp and add runtime contract primitive tests\n\nValidation:\n- cmake -S framekit -B framekit/build-issue136 -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF -DCMAKE_BUILD_TYPE=Release\n- cmake --build framekit/build-issue136\n- ctest --test-dir framekit/build-issue136 --output-on-failure\n\nCloses #136