### PR TITLE
feat(core): add execution task submission semantics

### DIFF
--- a/include/framekit/service/execution.hpp
+++ b/include/framekit/service/execution.hpp
@@ -3,9 +3,11 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <exception>
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>
@@ -29,6 +31,23 @@ struct ExecutionServiceShutdownRecord {
     ExecutionServiceOwnership ownership = ExecutionServiceOwnership::kContextOwned;
 };
 
+using ExecutionTaskId = std::uint64_t;
+
+enum class ExecutionTaskState : std::uint8_t {
+    kQueued = 0,
+    kRunning = 1,
+    kCompleted = 2,
+    kCancelled = 3,
+    kFailed = 4,
+    kRejected = 5,
+};
+
+struct ExecutionTaskResult {
+    ExecutionTaskId task_id = 0;
+    ExecutionTaskState state = ExecutionTaskState::kRejected;
+    std::string detail;
+};
+
 class IExecutionService {
 public:
     virtual ~IExecutionService() = default;
@@ -36,6 +55,162 @@ public:
     virtual bool Submit(std::function<void()> task) = 0;
     virtual bool BeginShutdown() = 0;
     virtual bool AwaitShutdown(std::chrono::milliseconds timeout) = 0;
+};
+
+class InlineExecutionService final : public IExecutionService {
+public:
+    InlineExecutionService() = default;
+
+    bool Submit(std::function<void()> task) override {
+        const auto result = SubmitTask(std::move(task));
+        return result.state == ExecutionTaskState::kQueued;
+    }
+
+    ExecutionTaskResult SubmitTask(std::function<void()> task) {
+        std::unique_lock lock(mutex_);
+
+        if (shutting_down_ || !task) {
+            return ExecutionTaskResult{
+                .task_id = 0,
+                .state = ExecutionTaskState::kRejected,
+                .detail = shutting_down_ ? "service is shutting down" : "task is empty",
+            };
+        }
+
+        const auto task_id = next_task_id_++;
+        pending_.push_back(PendingTask{
+            .task_id = task_id,
+            .task = std::move(task),
+        });
+
+        const auto queued = ExecutionTaskResult{
+            .task_id = task_id,
+            .state = ExecutionTaskState::kQueued,
+            .detail = "queued",
+        };
+        results_[task_id] = queued;
+        return queued;
+    }
+
+    bool Cancel(ExecutionTaskId task_id) {
+        std::unique_lock lock(mutex_);
+        if (shutting_down_) {
+            return false;
+        }
+
+        for (auto it = pending_.begin(); it != pending_.end(); ++it) {
+            if (it->task_id != task_id) {
+                continue;
+            }
+
+            pending_.erase(it);
+            results_[task_id] = ExecutionTaskResult{
+                .task_id = task_id,
+                .state = ExecutionTaskState::kCancelled,
+                .detail = "cancelled before execution",
+            };
+            return true;
+        }
+
+        return false;
+    }
+
+    std::vector<ExecutionTaskResult> Drain() {
+        std::vector<PendingTask> to_run;
+        {
+            std::unique_lock lock(mutex_);
+            to_run.swap(pending_);
+        }
+
+        std::vector<ExecutionTaskResult> drained;
+        drained.reserve(to_run.size());
+
+        for (auto& pending : to_run) {
+            {
+                std::unique_lock lock(mutex_);
+                results_[pending.task_id] = ExecutionTaskResult{
+                    .task_id = pending.task_id,
+                    .state = ExecutionTaskState::kRunning,
+                    .detail = "running",
+                };
+            }
+
+            ExecutionTaskResult outcome{
+                .task_id = pending.task_id,
+                .state = ExecutionTaskState::kCompleted,
+                .detail = "completed",
+            };
+
+            try {
+                pending.task();
+            } catch (const std::exception& ex) {
+                outcome.state = ExecutionTaskState::kFailed;
+                outcome.detail = ex.what();
+            } catch (...) {
+                outcome.state = ExecutionTaskState::kFailed;
+                outcome.detail = "task threw non-standard exception";
+            }
+
+            {
+                std::unique_lock lock(mutex_);
+                results_[pending.task_id] = outcome;
+            }
+            drained.push_back(outcome);
+        }
+
+        return drained;
+    }
+
+    bool BeginShutdown() override {
+        std::unique_lock lock(mutex_);
+        if (shutting_down_) {
+            return true;
+        }
+
+        shutting_down_ = true;
+        for (const auto& pending : pending_) {
+            results_[pending.task_id] = ExecutionTaskResult{
+                .task_id = pending.task_id,
+                .state = ExecutionTaskState::kCancelled,
+                .detail = "cancelled by shutdown",
+            };
+        }
+        pending_.clear();
+        return true;
+    }
+
+    bool AwaitShutdown(std::chrono::milliseconds timeout) override {
+        (void)timeout;
+        std::shared_lock lock(mutex_);
+        return shutting_down_;
+    }
+
+    std::size_t PendingCount() const {
+        std::shared_lock lock(mutex_);
+        return pending_.size();
+    }
+
+    std::optional<ExecutionTaskResult> FindResult(ExecutionTaskId task_id) const {
+        std::shared_lock lock(mutex_);
+        const auto found = results_.find(task_id);
+        if (found == results_.end()) {
+            return std::nullopt;
+        }
+
+        return found->second;
+    }
+
+private:
+    struct PendingTask {
+        ExecutionTaskId task_id = 0;
+        std::function<void()> task;
+    };
+
+    mutable std::shared_mutex mutex_;
+    bool shutting_down_ = false;
+    ExecutionTaskId next_task_id_ = 1;
+    std::vector<PendingTask> pending_;
+    std::unordered_map<ExecutionTaskId, ExecutionTaskResult> results_;
 };
 
 class ExecutionServiceRegistry {

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -226,6 +227,49 @@ void TestExecutionServiceRegistry() {
     failure_service->await_shutdown_result = false;
     REQUIRE(failure_registry.Register(failure_service, "failure"));
     REQUIRE(!failure_registry.BeginShutdown(std::chrono::milliseconds{0}));
+}
+
+void TestInlineExecutionServiceSemantics() {
+    framekit::runtime::InlineExecutionService service;
+
+    int executed = 0;
+    const auto first = service.SubmitTask([&executed]() { executed += 1; });
+    const auto second = service.SubmitTask([&executed]() { executed += 10; });
+
+    REQUIRE(first.state == framekit::runtime::ExecutionTaskState::kQueued);
+    REQUIRE(second.state == framekit::runtime::ExecutionTaskState::kQueued);
+    REQUIRE(service.PendingCount() == 2);
+
+    REQUIRE(service.Cancel(second.task_id));
+    REQUIRE(service.PendingCount() == 1);
+    auto cancelled = service.FindResult(second.task_id);
+    REQUIRE(cancelled.has_value());
+    REQUIRE(cancelled->state == framekit::runtime::ExecutionTaskState::kCancelled);
+
+    const auto drained = service.Drain();
+    REQUIRE(drained.size() == 1);
+    REQUIRE(drained.front().task_id == first.task_id);
+    REQUIRE(drained.front().state == framekit::runtime::ExecutionTaskState::kCompleted);
+    REQUIRE(executed == 1);
+
+    auto completed = service.FindResult(first.task_id);
+    REQUIRE(completed.has_value());
+    REQUIRE(completed->state == framekit::runtime::ExecutionTaskState::kCompleted);
+
+    const auto faulty = service.SubmitTask([]() {
+        throw std::runtime_error("boom");
+    });
+    REQUIRE(faulty.state == framekit::runtime::ExecutionTaskState::kQueued);
+    const auto fault_results = service.Drain();
+    REQUIRE(fault_results.size() == 1);
+    REQUIRE(fault_results.front().state == framekit::runtime::ExecutionTaskState::kFailed);
+    REQUIRE(fault_results.front().detail == "boom");
+
+    REQUIRE(service.BeginShutdown());
+    REQUIRE(service.AwaitShutdown(std::chrono::milliseconds{0}));
+
+    const auto rejected = service.SubmitTask([]() {});
+    REQUIRE(rejected.state == framekit::runtime::ExecutionTaskState::kRejected);
 }
 
 void TestModuleGraphValidation() {
@@ -561,6 +605,7 @@ int main() {
     TestLoopPolicyValidation();
     TestServiceContext();
     TestExecutionServiceRegistry();
+    TestInlineExecutionServiceSemantics();
     TestModuleGraphValidation();
     TestEventBusSemantics();
     TestKernelRuntime();


### PR DESCRIPTION
Summary:\n- add additive execution task contract types and baseline inline queue execution service\n- implement submit/cancel/drain result semantics with shutdown rejection and fault propagation\n- expand runtime primitive tests for task submission, cancellation boundaries, result delivery, and fault outcomes\n\nValidation:\n- cmake -S framekit -B framekit/build-issue138 -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF -DCMAKE_BUILD_TYPE=Release\n- cmake --build framekit/build-issue138\n- ctest --test-dir framekit/build-issue138 --output-on-failure\n\nCloses #138