### PR TITLE
feat(core): add scheduler policy and execution metrics

### DIFF
--- a/include/framekit/service/execution.hpp
+++ b/include/framekit/service/execution.hpp
@@ -48,6 +48,27 @@ struct ExecutionTaskResult {
     std::string detail;
 };
 
+enum class SchedulerPolicyKind : std::uint8_t {
+    kSingleThreaded = 0,
+    kFixedPool = 1,
+    kStageAffine = 2,
+};
+
+struct SchedulerPolicyConfig {
+    SchedulerPolicyKind kind = SchedulerPolicyKind::kSingleThreaded;
+    std::size_t worker_count = 1;
+    bool stage_affinity_enabled = false;
+};
+
+struct ExecutionServiceMetrics {
+    std::uint64_t submitted = 0;
+    std::uint64_t rejected = 0;
+    std::uint64_t cancelled = 0;
+    std::uint64_t completed = 0;
+    std::uint64_t failed = 0;
+    std::size_t pending = 0;
+};
+
 class IExecutionService {
 public:
     virtual ~IExecutionService() = default;
@@ -61,6 +82,22 @@ class InlineExecutionService final : public IExecutionService {
 public:
     InlineExecutionService() = default;
 
+    void ConfigurePolicy(SchedulerPolicyConfig policy) {
+        std::unique_lock lock(mutex_);
+        policy_ = std::move(policy);
+        if (policy_.kind == SchedulerPolicyKind::kSingleThreaded) {
+            policy_.worker_count = 1;
+            policy_.stage_affinity_enabled = false;
+        } else if (policy_.worker_count == 0) {
+            policy_.worker_count = 1;
+        }
+    }
+
+    SchedulerPolicyConfig Policy() const {
+        std::shared_lock lock(mutex_);
+        return policy_;
+    }
+
     bool Submit(std::function<void()> task) override {
         const auto result = SubmitTask(std::move(task));
         return result.state == ExecutionTaskState::kQueued;
@@ -70,6 +107,7 @@ public:
         std::unique_lock lock(mutex_);
 
         if (shutting_down_ || !task) {
+            metrics_.rejected += 1;
             return ExecutionTaskResult{
                 .task_id = 0,
                 .state = ExecutionTaskState::kRejected,
@@ -89,6 +127,8 @@ public:
             .detail = "queued",
         };
         results_[task_id] = queued;
+        metrics_.submitted += 1;
+        metrics_.pending = pending_.size();
         return queued;
     }
 
@@ -109,6 +149,8 @@ public:
                 .state = ExecutionTaskState::kCancelled,
                 .detail = "cancelled before execution",
             };
+            metrics_.cancelled += 1;
+            metrics_.pending = pending_.size();
             return true;
         }
 
@@ -120,6 +162,7 @@ public:
         {
             std::unique_lock lock(mutex_);
             to_run.swap(pending_);
+            metrics_.pending = pending_.size();
         }
 
         std::vector<ExecutionTaskResult> drained;
@@ -154,6 +197,11 @@ public:
             {
                 std::unique_lock lock(mutex_);
                 results_[pending.task_id] = outcome;
+                if (outcome.state == ExecutionTaskState::kCompleted) {
+                    metrics_.completed += 1;
+                } else if (outcome.state == ExecutionTaskState::kFailed) {
+                    metrics_.failed += 1;
+                }
             }
             drained.push_back(outcome);
         }
@@ -174,8 +222,10 @@ public:
                 .state = ExecutionTaskState::kCancelled,
                 .detail = "cancelled by shutdown",
             };
+            metrics_.cancelled += 1;
         }
         pending_.clear();
+        metrics_.pending = pending_.size();
         return true;
     }
 
@@ -200,6 +250,11 @@ public:
         return found->second;
     }
 
+    ExecutionServiceMetrics Metrics() const {
+        std::shared_lock lock(mutex_);
+        return metrics_;
+    }
+
 private:
     struct PendingTask {
         ExecutionTaskId task_id = 0;
@@ -208,6 +263,8 @@ private:
 
     mutable std::shared_mutex mutex_;
     bool shutting_down_ = false;
+    SchedulerPolicyConfig policy_;
+    ExecutionServiceMetrics metrics_;
     ExecutionTaskId next_task_id_ = 1;
     std::vector<PendingTask> pending_;
     std::unordered_map<ExecutionTaskId, ExecutionTaskResult> results_;

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -232,6 +232,29 @@ void TestExecutionServiceRegistry() {
 void TestInlineExecutionServiceSemantics() {
     framekit::runtime::InlineExecutionService service;
 
+    const auto default_policy = service.Policy();
+    REQUIRE(default_policy.kind == framekit::runtime::SchedulerPolicyKind::kSingleThreaded);
+    REQUIRE(default_policy.worker_count == 1);
+
+    service.ConfigurePolicy(framekit::runtime::SchedulerPolicyConfig{
+        .kind = framekit::runtime::SchedulerPolicyKind::kFixedPool,
+        .worker_count = 4,
+        .stage_affinity_enabled = false,
+    });
+    auto fixed_pool = service.Policy();
+    REQUIRE(fixed_pool.kind == framekit::runtime::SchedulerPolicyKind::kFixedPool);
+    REQUIRE(fixed_pool.worker_count == 4);
+
+    service.ConfigurePolicy(framekit::runtime::SchedulerPolicyConfig{
+        .kind = framekit::runtime::SchedulerPolicyKind::kStageAffine,
+        .worker_count = 0,
+        .stage_affinity_enabled = true,
+    });
+    auto stage_affine = service.Policy();
+    REQUIRE(stage_affine.kind == framekit::runtime::SchedulerPolicyKind::kStageAffine);
+    REQUIRE(stage_affine.worker_count == 1);
+    REQUIRE(stage_affine.stage_affinity_enabled);
+
     int executed = 0;
     const auto first = service.SubmitTask([&executed]() { executed += 1; });
     const auto second = service.SubmitTask([&executed]() { executed += 10; });
@@ -239,9 +262,15 @@ void TestInlineExecutionServiceSemantics() {
     REQUIRE(first.state == framekit::runtime::ExecutionTaskState::kQueued);
     REQUIRE(second.state == framekit::runtime::ExecutionTaskState::kQueued);
     REQUIRE(service.PendingCount() == 2);
+    auto metrics = service.Metrics();
+    REQUIRE(metrics.submitted == 2);
+    REQUIRE(metrics.pending == 2);
 
     REQUIRE(service.Cancel(second.task_id));
     REQUIRE(service.PendingCount() == 1);
+    metrics = service.Metrics();
+    REQUIRE(metrics.cancelled == 1);
+    REQUIRE(metrics.pending == 1);
     auto cancelled = service.FindResult(second.task_id);
     REQUIRE(cancelled.has_value());
     REQUIRE(cancelled->state == framekit::runtime::ExecutionTaskState::kCancelled);
@@ -251,6 +280,9 @@ void TestInlineExecutionServiceSemantics() {
     REQUIRE(drained.front().task_id == first.task_id);
     REQUIRE(drained.front().state == framekit::runtime::ExecutionTaskState::kCompleted);
     REQUIRE(executed == 1);
+    metrics = service.Metrics();
+    REQUIRE(metrics.completed == 1);
+    REQUIRE(metrics.pending == 0);
 
     auto completed = service.FindResult(first.task_id);
     REQUIRE(completed.has_value());
@@ -264,12 +296,16 @@ void TestInlineExecutionServiceSemantics() {
     REQUIRE(fault_results.size() == 1);
     REQUIRE(fault_results.front().state == framekit::runtime::ExecutionTaskState::kFailed);
     REQUIRE(fault_results.front().detail == "boom");
+    metrics = service.Metrics();
+    REQUIRE(metrics.failed == 1);
 
     REQUIRE(service.BeginShutdown());
     REQUIRE(service.AwaitShutdown(std::chrono::milliseconds{0}));
 
     const auto rejected = service.SubmitTask([]() {});
     REQUIRE(rejected.state == framekit::runtime::ExecutionTaskState::kRejected);
+    metrics = service.Metrics();
+    REQUIRE(metrics.rejected == 1);
 }
 
 void TestModuleGraphValidation() {


### PR DESCRIPTION
Summary:\n- add additive scheduler policy config surface (single-threaded, fixed-pool metadata, stage-affine metadata)\n- expose execution metrics counters for submitted/rejected/cancelled/completed/failed/pending\n- extend inline execution service tests to validate policy normalization and metrics transitions\n\nValidation:\n- cmake -S framekit -B framekit/build-issue140 -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF -DCMAKE_BUILD_TYPE=Release\n- cmake --build framekit/build-issue140\n- ctest --test-dir framekit/build-issue140 --output-on-failure\n\nCloses #140