### PR TITLE
test(core): add execution benchmark baseline harness

### DIFF
--- a/docs/doctrine/execution-service-benchmark-baseline-2026-03-30.md
+++ b/docs/doctrine/execution-service-benchmark-baseline-2026-03-30.md
@@ -1,0 +1,60 @@
+# Execution Service Benchmark Baseline (2026-03-30)
+
+Status: Stable
+Last Reviewed: 2026-03-30
+
+## Purpose
+
+Provide a repeatable, non-gating benchmark harness for the baseline execution
+service contract introduced in scheduler roadmap track #114.
+
+This benchmark is advisory. It does not gate CI and should be interpreted as a
+relative signal across local reruns on the same machine.
+
+## Harness
+
+Executable target:
+
+- `framekit_execution_service_benchmark`
+
+Source:
+
+- `tests/test_execution_service_benchmark.cpp`
+
+Workload:
+
+- queue `N` tasks into `InlineExecutionService`
+- drain all queued tasks
+- verify completion states and checksum integrity
+- print submit/drain timings and execution metrics
+
+## Run Command
+
+```bash
+cmake -S . -B build-benchmark -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build-benchmark --target framekit_execution_service_benchmark
+./build-benchmark/tests/framekit_execution_service_benchmark 100000
+```
+
+## Sample Output (Local)
+
+```text
+execution-service benchmark
+task_count=100000
+submit_ms=7
+drain_ms=4
+metrics.submitted=100000
+metrics.completed=100000
+metrics.failed=0
+metrics.cancelled=0
+metrics.rejected=0
+```
+
+## Interpretation Guidance
+
+- `submit_ms` tracks queue insertion overhead.
+- `drain_ms` tracks inline execution throughput.
+- Any non-zero `failed`, `cancelled`, or `rejected` values in this workload are
+  unexpected and should be investigated.
+- Compare against prior runs on the same machine/configuration for trend
+  analysis rather than absolute cross-machine comparisons.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -28,5 +28,6 @@ Public include layout is organized by concern under `include/framekit/`:
 For v2 scope and boundaries, see the [FrameKit v2 Charter](charter-v2.md).
 For platform support and validation pathways, see the [Platform Support Matrix](platform-support-matrix.md).
 For integration composition modes and bridge-module patterns, see the [Composition Matrix](composition-matrix.md).
+For scheduler benchmark baseline guidance, see the [Execution Service Benchmark Baseline (2026-03-30)](doctrine/execution-service-benchmark-baseline-2026-03-30.md).
 For latest contract-drift evidence and remediation traceability, see the [API/Docs Contract Alignment Audit (2026-03-29)](doctrine/api-doc-contract-alignment-2026-03-29.md).
 For the sequenced post-release backlog after `v2.0.0`, see the [Post-Release Roadmap (2026-03-29)](doctrine/post-release-roadmap-2026-03-29.md).

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,3 +48,9 @@ add_executable(framekit_fault_policy_runtime_test
 
 target_link_libraries(framekit_fault_policy_runtime_test PRIVATE FrameKit::Core)
 add_test(NAME framekit_fault_policy_runtime_test COMMAND framekit_fault_policy_runtime_test)
+
+add_executable(framekit_execution_service_benchmark
+    test_execution_service_benchmark.cpp
+)
+
+target_link_libraries(framekit_execution_service_benchmark PRIVATE FrameKit::Core)

--- a/tests/test_execution_service_benchmark.cpp
+++ b/tests/test_execution_service_benchmark.cpp
@@ -1,0 +1,80 @@
+#include "framekit/framekit.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+namespace {
+
+std::uint64_t ParsePositiveArg(const char* value, std::uint64_t fallback) {
+    if (!value) {
+        return fallback;
+    }
+
+    try {
+        const auto parsed = std::stoull(value);
+        return parsed == 0 ? fallback : parsed;
+    } catch (...) {
+        return fallback;
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    const std::uint64_t task_count = argc > 1 ? ParsePositiveArg(argv[1], 100000) : 100000;
+
+    framekit::runtime::InlineExecutionService service;
+
+    std::uint64_t checksum = 0;
+    const auto submit_start = std::chrono::steady_clock::now();
+    for (std::uint64_t index = 1; index <= task_count; ++index) {
+        const auto result = service.SubmitTask([&checksum, index]() {
+            checksum += index;
+        });
+        if (result.state != framekit::runtime::ExecutionTaskState::kQueued) {
+            std::cerr << "task submission rejected at index " << index << '\n';
+            return 1;
+        }
+    }
+    const auto submit_end = std::chrono::steady_clock::now();
+
+    const auto drain_start = std::chrono::steady_clock::now();
+    const auto drained = service.Drain();
+    const auto drain_end = std::chrono::steady_clock::now();
+
+    if (drained.size() != task_count) {
+        std::cerr << "unexpected drained task count: " << drained.size() << '\n';
+        return 2;
+    }
+
+    for (const auto& result : drained) {
+        if (result.state != framekit::runtime::ExecutionTaskState::kCompleted) {
+            std::cerr << "task did not complete successfully: id=" << result.task_id << '\n';
+            return 3;
+        }
+    }
+
+    const auto expected_checksum = (task_count * (task_count + 1)) / 2;
+    if (checksum != expected_checksum) {
+        std::cerr << "checksum mismatch: got " << checksum << ", expected " << expected_checksum << '\n';
+        return 4;
+    }
+
+    const auto submit_ms = std::chrono::duration_cast<std::chrono::milliseconds>(submit_end - submit_start).count();
+    const auto drain_ms = std::chrono::duration_cast<std::chrono::milliseconds>(drain_end - drain_start).count();
+
+    const auto metrics = service.Metrics();
+    std::cout << "execution-service benchmark" << '\n';
+    std::cout << "task_count=" << task_count << '\n';
+    std::cout << "submit_ms=" << submit_ms << '\n';
+    std::cout << "drain_ms=" << drain_ms << '\n';
+    std::cout << "metrics.submitted=" << metrics.submitted << '\n';
+    std::cout << "metrics.completed=" << metrics.completed << '\n';
+    std::cout << "metrics.failed=" << metrics.failed << '\n';
+    std::cout << "metrics.cancelled=" << metrics.cancelled << '\n';
+    std::cout << "metrics.rejected=" << metrics.rejected << '\n';
+
+    return 0;
+}


### PR DESCRIPTION
Summary:\n- add non-gating execution benchmark harness target using InlineExecutionService\n- document repeatable benchmark command and baseline sample output\n- link benchmark baseline doctrine from overview\n\nValidation:\n- cmake -S framekit -B framekit/build-issue142 -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF -DCMAKE_BUILD_TYPE=Release\n- cmake --build framekit/build-issue142 --target framekit_execution_service_benchmark\n- framekit/build-issue142/tests/framekit_execution_service_benchmark 100000\n- cmake --build framekit/build-issue142\n- ctest --test-dir framekit/build-issue142 --output-on-failure\n\nCloses #142