### PR TITLE
feat(core): add dynamic module loader contract surface

### DIFF
--- a/docs/doctrine/dynamic-module-loader-contract-2026-03-30.md
+++ b/docs/doctrine/dynamic-module-loader-contract-2026-03-30.md
@@ -1,0 +1,45 @@
+# Dynamic Module Loader Contract (2026-03-30)
+
+Status: Draft
+Last Reviewed: 2026-03-30
+
+## Purpose
+
+Define the first opt-in contract surface for post-release dynamic module
+loading work in track #113 without enabling runtime dynamic loading by default.
+
+## Contract Surface
+
+Header:
+
+- `include/framekit/module/dynamic_loader.hpp`
+
+Primary contract types:
+
+- `DynamicModuleManifest`
+- `DynamicModuleDecision`
+- `DynamicModuleRefusalReason`
+- `DynamicModuleLoadState`
+- `IDynamicModuleLoader`
+- `ValidateDynamicModuleManifest(...)`
+
+## Baseline Rules
+
+- Manifest `module_id` and `module_version` must be non-empty.
+- Required and optional dependency entries must be non-empty.
+- A module cannot depend on itself.
+- Dependency entries must be unique within each list.
+- A dependency cannot appear in both required and optional lists.
+
+## Safety Position
+
+- This slice introduces contract shapes and deterministic validation only.
+- No runtime behavior change is introduced for static baseline startup/shutdown.
+- Dynamic loading remains opt-in and inactive unless a future slice wires
+  runtime integration hooks.
+
+## Follow-up Slices
+
+- Runtime load/unload state integration and refusal semantics.
+- Rollback/fault handling for partial dynamic load failures.
+- Explicit unload restrictions and dependency-safe refusal paths.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -29,5 +29,6 @@ For v2 scope and boundaries, see the [FrameKit v2 Charter](charter-v2.md).
 For platform support and validation pathways, see the [Platform Support Matrix](platform-support-matrix.md).
 For integration composition modes and bridge-module patterns, see the [Composition Matrix](composition-matrix.md).
 For scheduler benchmark baseline guidance, see the [Execution Service Benchmark Baseline (2026-03-30)](doctrine/execution-service-benchmark-baseline-2026-03-30.md).
+For optional dynamic-loading contract surface details, see the [Dynamic Module Loader Contract (2026-03-30)](doctrine/dynamic-module-loader-contract-2026-03-30.md).
 For latest contract-drift evidence and remediation traceability, see the [API/Docs Contract Alignment Audit (2026-03-29)](doctrine/api-doc-contract-alignment-2026-03-29.md).
 For the sequenced post-release backlog after `v2.0.0`, see the [Post-Release Roadmap (2026-03-29)](doctrine/post-release-roadmap-2026-03-29.md).

--- a/include/framekit/framekit.hpp
+++ b/include/framekit/framekit.hpp
@@ -35,6 +35,7 @@
 #include "framekit/service/context.hpp"
 #include "framekit/service/execution.hpp"
 #include "framekit/service/bootstrap.hpp"
+#include "framekit/module/dynamic_loader.hpp"
 #include "framekit/module/graph.hpp"
 
 // Multiprocess support contracts.

--- a/include/framekit/module/dynamic_loader.hpp
+++ b/include/framekit/module/dynamic_loader.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+
+namespace framekit::runtime {
+
+enum class DynamicModuleRefusalReason : std::uint8_t {
+    kNone = 0,
+    kInvalidManifest = 1,
+    kDuplicateModuleId = 2,
+    kDependencyUnavailable = 3,
+    kIllegalLifecycleState = 4,
+    kUnloadNotAllowed = 5,
+};
+
+enum class DynamicModuleLoadState : std::uint8_t {
+    kDiscovered = 0,
+    kRegistered = 1,
+    kLoaded = 2,
+    kStarted = 3,
+    kRefused = 4,
+    kUnloaded = 5,
+};
+
+struct DynamicModuleManifest {
+    std::string module_id;
+    std::string module_version;
+    std::vector<std::string> required_dependencies;
+    std::vector<std::string> optional_dependencies;
+    std::vector<std::string> exported_services;
+    bool hot_unload_allowed = false;
+};
+
+struct DynamicModuleDecision {
+    bool accepted = false;
+    DynamicModuleRefusalReason refusal_reason = DynamicModuleRefusalReason::kNone;
+    std::string message;
+};
+
+class IDynamicModuleLoader {
+public:
+    virtual ~IDynamicModuleLoader() = default;
+
+    virtual DynamicModuleDecision RegisterManifest(const DynamicModuleManifest& manifest) = 0;
+    virtual DynamicModuleDecision LoadModule(std::string_view module_id) = 0;
+    virtual DynamicModuleDecision UnloadModule(std::string_view module_id) = 0;
+};
+
+inline bool ValidateDynamicModuleManifest(const DynamicModuleManifest& manifest, std::string* error) {
+    auto fail = [error](std::string message) {
+        if (error) {
+            *error = std::move(message);
+        }
+        return false;
+    };
+
+    if (manifest.module_id.empty()) {
+        return fail("module manifest id must be non-empty");
+    }
+
+    if (manifest.module_version.empty()) {
+        return fail("module manifest version must be non-empty");
+    }
+
+    if (manifest.required_dependencies.empty() && manifest.optional_dependencies.empty()) {
+        return true;
+    }
+
+    std::unordered_set<std::string> required_set;
+    required_set.reserve(manifest.required_dependencies.size());
+    for (const auto& dependency : manifest.required_dependencies) {
+        if (dependency.empty()) {
+            return fail("required dependency id must be non-empty");
+        }
+        if (dependency == manifest.module_id) {
+            return fail("module manifest cannot require itself");
+        }
+        if (!required_set.insert(dependency).second) {
+            return fail("required dependency list contains duplicate entries");
+        }
+    }
+
+    std::unordered_set<std::string> optional_set;
+    optional_set.reserve(manifest.optional_dependencies.size());
+    for (const auto& dependency : manifest.optional_dependencies) {
+        if (dependency.empty()) {
+            return fail("optional dependency id must be non-empty");
+        }
+        if (dependency == manifest.module_id) {
+            return fail("module manifest cannot optionally depend on itself");
+        }
+        if (!optional_set.insert(dependency).second) {
+            return fail("optional dependency list contains duplicate entries");
+        }
+        if (required_set.find(dependency) != required_set.end()) {
+            return fail("dependency cannot be both required and optional");
+        }
+    }
+
+    return true;
+}
+
+} // namespace framekit::runtime

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -383,6 +383,43 @@ void TestModuleGraphValidation() {
     REQUIRE(invalid_id_result.errors.front().code == framekit::runtime::ModuleGraphErrorCode::kInvalidModuleId);
 }
 
+void TestDynamicModuleManifestValidation() {
+    framekit::runtime::DynamicModuleManifest manifest;
+    manifest.module_id = "dynamic-ui";
+    manifest.module_version = "1.0.0";
+    manifest.required_dependencies = {"core"};
+    manifest.optional_dependencies = {"telemetry"};
+
+    std::string error;
+    REQUIRE(framekit::runtime::ValidateDynamicModuleManifest(manifest, &error));
+    REQUIRE(error.empty());
+
+    framekit::runtime::DynamicModuleManifest empty_id = manifest;
+    empty_id.module_id.clear();
+    REQUIRE(!framekit::runtime::ValidateDynamicModuleManifest(empty_id, &error));
+    REQUIRE(error.find("non-empty") != std::string::npos);
+
+    framekit::runtime::DynamicModuleManifest missing_version = manifest;
+    missing_version.module_version.clear();
+    REQUIRE(!framekit::runtime::ValidateDynamicModuleManifest(missing_version, &error));
+    REQUIRE(error.find("version") != std::string::npos);
+
+    framekit::runtime::DynamicModuleManifest duplicate_required = manifest;
+    duplicate_required.required_dependencies = {"core", "core"};
+    REQUIRE(!framekit::runtime::ValidateDynamicModuleManifest(duplicate_required, &error));
+    REQUIRE(error.find("duplicate") != std::string::npos);
+
+    framekit::runtime::DynamicModuleManifest required_optional_overlap = manifest;
+    required_optional_overlap.optional_dependencies = {"core"};
+    REQUIRE(!framekit::runtime::ValidateDynamicModuleManifest(required_optional_overlap, &error));
+    REQUIRE(error.find("required and optional") != std::string::npos);
+
+    framekit::runtime::DynamicModuleManifest self_dependency = manifest;
+    self_dependency.required_dependencies = {"dynamic-ui"};
+    REQUIRE(!framekit::runtime::ValidateDynamicModuleManifest(self_dependency, &error));
+    REQUIRE(error.find("cannot require itself") != std::string::npos);
+}
+
 void TestEventBusSemantics() {
     framekit::runtime::EventBus bus;
 
@@ -643,6 +680,7 @@ int main() {
     TestExecutionServiceRegistry();
     TestInlineExecutionServiceSemantics();
     TestModuleGraphValidation();
+    TestDynamicModuleManifestValidation();
     TestEventBusSemantics();
     TestKernelRuntime();
     TestKernelRuntimeModuleLifecycleOrchestration();


### PR DESCRIPTION
Summary:\n- add additive dynamic loader contract header and manifest validation rules\n- export the dynamic loader contract through framekit umbrella includes\n- add runtime primitive tests for manifest validation/refusal classification and doctrine contract notes\n\nValidation:\n- cmake -S framekit -B framekit/build-issue145 -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF -DCMAKE_BUILD_TYPE=Release\n- cmake --build framekit/build-issue145\n- ctest --test-dir framekit/build-issue145 --output-on-failure\n\nCloses #145