### PR TITLE
feat(core): add dynamic load/unload decision semantics

### DIFF
--- a/docs/doctrine/dynamic-module-loader-contract-2026-03-30.md
+++ b/docs/doctrine/dynamic-module-loader-contract-2026-03-30.md
@@ -20,8 +20,11 @@ Primary contract types:
 - `DynamicModuleDecision`
 - `DynamicModuleRefusalReason`
 - `DynamicModuleLoadState`
+- `DynamicLoaderHostPhase`
 - `IDynamicModuleLoader`
 - `ValidateDynamicModuleManifest(...)`
+- `EvaluateDynamicLoadRequest(...)`
+- `EvaluateDynamicUnloadRequest(...)`
 
 ## Baseline Rules
 
@@ -37,6 +40,8 @@ Primary contract types:
 - No runtime behavior change is introduced for static baseline startup/shutdown.
 - Dynamic loading remains opt-in and inactive unless a future slice wires
   runtime integration hooks.
+- Load/unload decision helpers provide deterministic refusal reasons without
+  mutating baseline startup/shutdown behavior.
 
 ## Follow-up Slices
 

--- a/include/framekit/module/dynamic_loader.hpp
+++ b/include/framekit/module/dynamic_loader.hpp
@@ -27,6 +27,14 @@ enum class DynamicModuleLoadState : std::uint8_t {
     kUnloaded = 5,
 };
 
+enum class DynamicLoaderHostPhase : std::uint8_t {
+    kBootstrapping = 0,
+    kInitializing = 1,
+    kRunning = 2,
+    kStopping = 3,
+    kStopped = 4,
+};
+
 struct DynamicModuleManifest {
     std::string module_id;
     std::string module_version;
@@ -50,6 +58,85 @@ public:
     virtual DynamicModuleDecision LoadModule(std::string_view module_id) = 0;
     virtual DynamicModuleDecision UnloadModule(std::string_view module_id) = 0;
 };
+
+inline DynamicModuleDecision EvaluateDynamicLoadRequest(
+    DynamicLoaderHostPhase host_phase,
+    bool module_already_registered,
+    bool dependencies_available) {
+    if (host_phase != DynamicLoaderHostPhase::kRunning) {
+        return DynamicModuleDecision{
+            .accepted = false,
+            .refusal_reason = DynamicModuleRefusalReason::kIllegalLifecycleState,
+            .message = "dynamic loading is only allowed while host phase is running",
+        };
+    }
+
+    if (module_already_registered) {
+        return DynamicModuleDecision{
+            .accepted = false,
+            .refusal_reason = DynamicModuleRefusalReason::kDuplicateModuleId,
+            .message = "module is already registered",
+        };
+    }
+
+    if (!dependencies_available) {
+        return DynamicModuleDecision{
+            .accepted = false,
+            .refusal_reason = DynamicModuleRefusalReason::kDependencyUnavailable,
+            .message = "required dependencies are unavailable",
+        };
+    }
+
+    return DynamicModuleDecision{
+        .accepted = true,
+        .refusal_reason = DynamicModuleRefusalReason::kNone,
+        .message = "load accepted",
+    };
+}
+
+inline DynamicModuleDecision EvaluateDynamicUnloadRequest(
+    DynamicLoaderHostPhase host_phase,
+    const DynamicModuleManifest& manifest,
+    bool module_is_loaded,
+    bool has_runtime_dependents) {
+    if (host_phase != DynamicLoaderHostPhase::kRunning) {
+        return DynamicModuleDecision{
+            .accepted = false,
+            .refusal_reason = DynamicModuleRefusalReason::kIllegalLifecycleState,
+            .message = "dynamic unload is only allowed while host phase is running",
+        };
+    }
+
+    if (!module_is_loaded) {
+        return DynamicModuleDecision{
+            .accepted = false,
+            .refusal_reason = DynamicModuleRefusalReason::kIllegalLifecycleState,
+            .message = "module is not loaded",
+        };
+    }
+
+    if (!manifest.hot_unload_allowed) {
+        return DynamicModuleDecision{
+            .accepted = false,
+            .refusal_reason = DynamicModuleRefusalReason::kUnloadNotAllowed,
+            .message = "module manifest does not allow hot unload",
+        };
+    }
+
+    if (has_runtime_dependents) {
+        return DynamicModuleDecision{
+            .accepted = false,
+            .refusal_reason = DynamicModuleRefusalReason::kDependencyUnavailable,
+            .message = "module has active dependents",
+        };
+    }
+
+    return DynamicModuleDecision{
+        .accepted = true,
+        .refusal_reason = DynamicModuleRefusalReason::kNone,
+        .message = "unload accepted",
+    };
+}
 
 inline bool ValidateDynamicModuleManifest(const DynamicModuleManifest& manifest, std::string* error) {
     auto fail = [error](std::string message) {

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -420,6 +420,58 @@ void TestDynamicModuleManifestValidation() {
     REQUIRE(error.find("cannot require itself") != std::string::npos);
 }
 
+void TestDynamicLoadUnloadDecisionSemantics() {
+    const auto accepted_load = framekit::runtime::EvaluateDynamicLoadRequest(
+        framekit::runtime::DynamicLoaderHostPhase::kRunning,
+        false,
+        true);
+    REQUIRE(accepted_load.accepted);
+    REQUIRE(accepted_load.refusal_reason == framekit::runtime::DynamicModuleRefusalReason::kNone);
+
+    const auto rejected_phase_load = framekit::runtime::EvaluateDynamicLoadRequest(
+        framekit::runtime::DynamicLoaderHostPhase::kInitializing,
+        false,
+        true);
+    REQUIRE(!rejected_phase_load.accepted);
+    REQUIRE(rejected_phase_load.refusal_reason == framekit::runtime::DynamicModuleRefusalReason::kIllegalLifecycleState);
+
+    const auto duplicate_load = framekit::runtime::EvaluateDynamicLoadRequest(
+        framekit::runtime::DynamicLoaderHostPhase::kRunning,
+        true,
+        true);
+    REQUIRE(!duplicate_load.accepted);
+    REQUIRE(duplicate_load.refusal_reason == framekit::runtime::DynamicModuleRefusalReason::kDuplicateModuleId);
+
+    framekit::runtime::DynamicModuleManifest manifest;
+    manifest.module_id = "dynamic-a";
+    manifest.module_version = "1.0.0";
+
+    const auto unload_not_allowed = framekit::runtime::EvaluateDynamicUnloadRequest(
+        framekit::runtime::DynamicLoaderHostPhase::kRunning,
+        manifest,
+        true,
+        false);
+    REQUIRE(!unload_not_allowed.accepted);
+    REQUIRE(unload_not_allowed.refusal_reason == framekit::runtime::DynamicModuleRefusalReason::kUnloadNotAllowed);
+
+    manifest.hot_unload_allowed = true;
+    const auto unload_has_dependents = framekit::runtime::EvaluateDynamicUnloadRequest(
+        framekit::runtime::DynamicLoaderHostPhase::kRunning,
+        manifest,
+        true,
+        true);
+    REQUIRE(!unload_has_dependents.accepted);
+    REQUIRE(unload_has_dependents.refusal_reason == framekit::runtime::DynamicModuleRefusalReason::kDependencyUnavailable);
+
+    const auto unload_accepted = framekit::runtime::EvaluateDynamicUnloadRequest(
+        framekit::runtime::DynamicLoaderHostPhase::kRunning,
+        manifest,
+        true,
+        false);
+    REQUIRE(unload_accepted.accepted);
+    REQUIRE(unload_accepted.refusal_reason == framekit::runtime::DynamicModuleRefusalReason::kNone);
+}
+
 void TestEventBusSemantics() {
     framekit::runtime::EventBus bus;
 
@@ -681,6 +733,7 @@ int main() {
     TestInlineExecutionServiceSemantics();
     TestModuleGraphValidation();
     TestDynamicModuleManifestValidation();
+    TestDynamicLoadUnloadDecisionSemantics();
     TestEventBusSemantics();
     TestKernelRuntime();
     TestKernelRuntimeModuleLifecycleOrchestration();


### PR DESCRIPTION
Summary:\n- add dynamic load/unload decision helpers with deterministic refusal reasons\n- enforce host lifecycle-state constraints and unload permission/dependency checks\n- extend runtime primitive tests and dynamic-loader doctrine notes for these semantics\n\nValidation:\n- cmake -S framekit -B framekit/build-issue147 -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF -DCMAKE_BUILD_TYPE=Release\n- cmake --build framekit/build-issue147\n- ctest --test-dir framekit/build-issue147 --output-on-failure\n\nCloses #147