### PR TITLE
feat(core): add dynamic rollback planning helpers

### DIFF
--- a/docs/doctrine/dynamic-module-loader-contract-2026-03-30.md
+++ b/docs/doctrine/dynamic-module-loader-contract-2026-03-30.md
@@ -25,6 +25,8 @@ Primary contract types:
 - `ValidateDynamicModuleManifest(...)`
 - `EvaluateDynamicLoadRequest(...)`
 - `EvaluateDynamicUnloadRequest(...)`
+- `BuildDynamicRollbackPlan(...)`
+- `AssessDynamicRollbackResult(...)`
 
 ## Baseline Rules
 
@@ -48,3 +50,10 @@ Primary contract types:
 - Runtime load/unload state integration and refusal semantics.
 - Rollback/fault handling for partial dynamic load failures.
 - Explicit unload restrictions and dependency-safe refusal paths.
+
+## Rollback Planning Notes
+
+- `BuildDynamicRollbackPlan(...)` derives deterministic reverse-order unload
+  steps for partially loaded dynamic modules.
+- `AssessDynamicRollbackResult(...)` classifies rollback success/failure to
+  support future fault escalation logic.

--- a/include/framekit/module/dynamic_loader.hpp
+++ b/include/framekit/module/dynamic_loader.hpp
@@ -50,6 +50,18 @@ struct DynamicModuleDecision {
     std::string message;
 };
 
+struct DynamicModuleRollbackPlan {
+    bool required = false;
+    std::string failed_module_id;
+    std::vector<std::string> unload_order;
+};
+
+struct DynamicModuleRollbackResult {
+    bool success = true;
+    std::size_t unload_failures = 0;
+    std::vector<std::string> failed_unloads;
+};
+
 class IDynamicModuleLoader {
 public:
     virtual ~IDynamicModuleLoader() = default;
@@ -135,6 +147,51 @@ inline DynamicModuleDecision EvaluateDynamicUnloadRequest(
         .accepted = true,
         .refusal_reason = DynamicModuleRefusalReason::kNone,
         .message = "unload accepted",
+    };
+}
+
+inline DynamicModuleRollbackPlan BuildDynamicRollbackPlan(
+    const std::vector<std::string>& loaded_modules_in_order,
+    std::string_view failed_module_id) {
+    DynamicModuleRollbackPlan plan;
+    plan.failed_module_id = std::string(failed_module_id);
+
+    if (failed_module_id.empty()) {
+        return plan;
+    }
+
+    auto it = std::find(
+        loaded_modules_in_order.begin(),
+        loaded_modules_in_order.end(),
+        failed_module_id);
+    if (it == loaded_modules_in_order.end()) {
+        return plan;
+    }
+
+    plan.required = true;
+    for (auto reverse = loaded_modules_in_order.rbegin(); reverse != loaded_modules_in_order.rend(); ++reverse) {
+        plan.unload_order.push_back(*reverse);
+        if (*reverse == failed_module_id) {
+            break;
+        }
+    }
+
+    return plan;
+}
+
+inline DynamicModuleDecision AssessDynamicRollbackResult(const DynamicModuleRollbackResult& rollback_result) {
+    if (rollback_result.success && rollback_result.unload_failures == 0 && rollback_result.failed_unloads.empty()) {
+        return DynamicModuleDecision{
+            .accepted = true,
+            .refusal_reason = DynamicModuleRefusalReason::kNone,
+            .message = "rollback succeeded",
+        };
+    }
+
+    return DynamicModuleDecision{
+        .accepted = false,
+        .refusal_reason = DynamicModuleRefusalReason::kIllegalLifecycleState,
+        .message = "rollback left modules in a partially loaded state",
     };
 }
 

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -472,6 +472,50 @@ void TestDynamicLoadUnloadDecisionSemantics() {
     REQUIRE(unload_accepted.refusal_reason == framekit::runtime::DynamicModuleRefusalReason::kNone);
 }
 
+void TestDynamicRollbackSemantics() {
+    const std::vector<std::string> loaded_order = {
+        "core",
+        "render",
+        "dynamic-ui",
+    };
+
+    const auto plan = framekit::runtime::BuildDynamicRollbackPlan(loaded_order, "dynamic-ui");
+    REQUIRE(plan.required);
+    REQUIRE(plan.failed_module_id == "dynamic-ui");
+    REQUIRE(plan.unload_order.size() == 1);
+    REQUIRE(plan.unload_order[0] == "dynamic-ui");
+
+    const auto mid_plan = framekit::runtime::BuildDynamicRollbackPlan(loaded_order, "render");
+    REQUIRE(mid_plan.required);
+    REQUIRE(mid_plan.unload_order.size() == 2);
+    REQUIRE(mid_plan.unload_order[0] == "dynamic-ui");
+    REQUIRE(mid_plan.unload_order[1] == "render");
+
+    const auto missing_plan = framekit::runtime::BuildDynamicRollbackPlan(loaded_order, "missing");
+    REQUIRE(!missing_plan.required);
+    REQUIRE(missing_plan.unload_order.empty());
+
+    const auto empty_plan = framekit::runtime::BuildDynamicRollbackPlan(loaded_order, "");
+    REQUIRE(!empty_plan.required);
+
+    const auto rollback_ok = framekit::runtime::AssessDynamicRollbackResult(
+        framekit::runtime::DynamicModuleRollbackResult{
+            .success = true,
+            .unload_failures = 0,
+            .failed_unloads = {},
+        });
+    REQUIRE(rollback_ok.accepted);
+
+    const auto rollback_failed = framekit::runtime::AssessDynamicRollbackResult(
+        framekit::runtime::DynamicModuleRollbackResult{
+            .success = false,
+            .unload_failures = 1,
+            .failed_unloads = {"render"},
+        });
+    REQUIRE(!rollback_failed.accepted);
+    REQUIRE(rollback_failed.refusal_reason == framekit::runtime::DynamicModuleRefusalReason::kIllegalLifecycleState);
+}
+
 void TestEventBusSemantics() {
     framekit::runtime::EventBus bus;
 
@@ -734,6 +778,7 @@ int main() {
     TestModuleGraphValidation();
     TestDynamicModuleManifestValidation();
     TestDynamicLoadUnloadDecisionSemantics();
+    TestDynamicRollbackSemantics();
     TestEventBusSemantics();
     TestKernelRuntime();
     TestKernelRuntimeModuleLifecycleOrchestration();


### PR DESCRIPTION
Summary:\n- add additive rollback planning/result contract types for partial dynamic-load failures\n- implement deterministic rollback plan derivation and rollback outcome assessment helpers\n- extend runtime primitive tests and doctrine contract notes for rollback semantics\n\nValidation:\n- cmake -S framekit -B framekit/build-issue149 -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF -DCMAKE_BUILD_TYPE=Release\n- cmake --build framekit/build-issue149\n- ctest --test-dir framekit/build-issue149 --output-on-failure\n\nCloses #149