### PR TITLE
fix(platform): harden startup rollback cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 - Release-evidence updates for the `v2.0.0` promotion flow.
+- Hardened platform startup cleanup when window creation fails after platform initialization.
+- Aligned Cocoa support wording and core v2 contract documentation status with the validated release baseline.
 
 ## v2.0.0
 - First public release of the rewritten, incompatible FrameKit v2 line.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(framekit VERSION 2.0.0 LANGUAGES C CXX)
 option(FRAMEKIT_BUILD_TESTS "Build framekit tests" ON)
 option(FRAMEKIT_BUILD_EXAMPLES "Build framekit examples" ON)
 option(FRAMEKIT_ENABLE_NETKIT "Enable NetKit-dependent framekit integrations" OFF)
-option(FRAMEKIT_ENABLE_COCOA "Enable experimental macOS Cocoa backend support" OFF)
+option(FRAMEKIT_ENABLE_COCOA "Enable macOS Cocoa backend support" OFF)
 
 set(FRAMEKIT_NETKIT_SOURCE_DIR "" CACHE PATH "Path to netkit source directory")
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Modular C/C++ application framework focused on single-process and multiprocess a
 - A runtime framework for building frontend/backend/worker style apps.
 - A contracts-first core where transport implementations can be optional.
 - A host for integrations with `netkit` and `mediakit`.
-- A window backend contract with experimental Apple Cocoa support on macOS.
+- A window backend contract with CI-validated Apple Cocoa support on macOS.
 
 ## Multiprocess Direction
 `framekit` owns multiprocess orchestration contracts and runtime behavior. Transport implementations are optional and supplied by `netkit`.
@@ -47,7 +47,7 @@ Core sample executables:
 - `framekit_single_process_example`
 - `framekit_multi_worker_example`
 
-Experimental Apple Cocoa backend (local/macOS only until dedicated validation lands):
+Apple Cocoa backend (macOS only, opt-in):
 ```bash
 cmake -S . -B build \
   -DFRAMEKIT_BUILD_TESTS=ON \

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,7 +1,7 @@
 # Architecture Decision Records (ADRs)
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/charter-v2.md
+++ b/docs/charter-v2.md
@@ -1,7 +1,7 @@
 # FrameKit v2 Charter
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/error-policy-matrix.md
+++ b/docs/error-policy-matrix.md
@@ -1,7 +1,7 @@
 # Error Policy Matrix by Loop Profile
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/event-input-semantics.md
+++ b/docs/event-input-semantics.md
@@ -1,7 +1,7 @@
 # Event and Input Semantics Contract
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/integration-boundary.md
+++ b/docs/integration-boundary.md
@@ -1,7 +1,7 @@
 # External Integration Boundary Contract
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/lifecycle-semantics.md
+++ b/docs/lifecycle-semantics.md
@@ -1,7 +1,7 @@
 # Lifecycle and Shutdown Semantics
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/loop-stage-graph-profiles.md
+++ b/docs/loop-stage-graph-profiles.md
@@ -1,7 +1,7 @@
 # Loop Stage Graph and Profile/Policy Specification
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/module-contract-dag-semantics.md
+++ b/docs/module-contract-dag-semantics.md
@@ -1,7 +1,7 @@
 # Module Contract and Dependency DAG Semantics
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/service-context-contract-freeze.md
+++ b/docs/service-context-contract-freeze.md
@@ -1,7 +1,7 @@
 # Service Context Contract and Freeze Policy
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/v2-stable-contracts.md
+++ b/docs/v2-stable-contracts.md
@@ -1,7 +1,7 @@
 # FrameKit v2 Stable Contract Inventory
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/include/framekit/platform/host_runtime.hpp
+++ b/include/framekit/platform/host_runtime.hpp
@@ -74,6 +74,7 @@ private:
     FaultPolicyRuntime fault_policy_;
     bool configured_ = false;
     bool running_ = false;
+    bool platform_initialized_ = false;
     bool window_created_ = false;
     bool frame_failed_ = false;
     bool has_last_tick_timestamp_ = false;

--- a/src/platform_host_runtime.cpp
+++ b/src/platform_host_runtime.cpp
@@ -36,6 +36,12 @@ bool PlatformHostRuntime::Configure(const LoopPolicy& policy, WindowSpec primary
         return false;
     }
 
+    if (platform_initialized_ || window_created_) {
+        last_error_ = "cannot configure platform runtime while cleanup is pending";
+        configured_ = false;
+        return false;
+    }
+
     if (!loop_runner_.Configure(policy)) {
         last_error_ = loop_runner_.LastError();
         configured_ = false;
@@ -196,6 +202,11 @@ bool PlatformHostRuntime::Start() {
         return false;
     }
 
+    if (platform_initialized_ || window_created_) {
+        last_error_ = "platform runtime cleanup is required before restart";
+        return false;
+    }
+
     const bool has_render_stages = HasActiveRenderStages();
     const bool can_auto_wire_cocoa =
         !platform_host_ &&
@@ -217,16 +228,25 @@ bool PlatformHostRuntime::Start() {
         last_error_ = "platform host initialization failed";
         return false;
     }
+    platform_initialized_ = true;
+
+    auto fail_after_platform_initialize = [this](std::string error) {
+        if (!platform_host_->Teardown()) {
+            error += "; platform teardown failed after startup failure";
+        } else {
+            platform_initialized_ = false;
+        }
+        last_error_ = std::move(error);
+        return false;
+    };
 
     if (has_render_stages) {
         if (!window_host_) {
-            last_error_ = "window host is required when render stages are active";
-            return false;
+            return fail_after_platform_initialize("window host is required when render stages are active");
         }
 
         if (!window_host_->CreatePrimaryWindow(primary_window_)) {
-            last_error_ = "window host failed to create primary window";
-            return false;
+            return fail_after_platform_initialize("window host failed to create primary window");
         }
 
         window_created_ = true;
@@ -268,7 +288,7 @@ bool PlatformHostRuntime::Tick() {
 }
 
 bool PlatformHostRuntime::Stop() {
-    if (!running_) {
+    if (!running_ && !platform_initialized_ && !window_created_) {
         return true;
     }
 
@@ -279,18 +299,21 @@ bool PlatformHostRuntime::Stop() {
             if (last_error_.empty()) {
                 last_error_ = "window host teardown failed";
             }
+        } else {
+            window_created_ = false;
         }
     }
 
-    if (!platform_host_->Teardown()) {
+    if (platform_initialized_ && platform_host_ && !platform_host_->Teardown()) {
         ok = false;
         if (last_error_.empty()) {
             last_error_ = "platform host teardown failed";
         }
+    } else {
+        platform_initialized_ = false;
     }
 
     running_ = false;
-    window_created_ = false;
     frame_failed_ = false;
     has_last_tick_timestamp_ = false;
     return ok;

--- a/tests/test_platform_host_runtime.cpp
+++ b/tests/test_platform_host_runtime.cpp
@@ -169,7 +169,58 @@ void TestStartFailsWhenRenderStagesActiveWithoutWindowHost() {
     runtime.SetPlatformHost(platform);
     REQUIRE(runtime.Configure(policy));
     REQUIRE(!runtime.Start());
-    REQUIRE(!runtime.LastError().empty());
+    REQUIRE(runtime.LastError().find("window host is required") != std::string::npos);
+    REQUIRE(!runtime.IsRunning());
+    REQUIRE(platform->initialize_calls == 1);
+    REQUIRE(platform->teardown_calls == 1);
+}
+
+void TestStartFailureOnWindowCreateTeardownsPlatform() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kGui;
+    policy.rendering_enabled = true;
+
+    auto platform = std::make_shared<FakePlatformHost>();
+    auto window = std::make_shared<FakeWindowHost>();
+    window->create_result = false;
+
+    framekit::runtime::PlatformHostRuntime runtime;
+    runtime.SetPlatformHost(platform);
+    runtime.SetWindowHost(window);
+    REQUIRE(runtime.Configure(policy));
+    REQUIRE(!runtime.Start());
+    REQUIRE(runtime.LastError().find("failed to create primary window") != std::string::npos);
+    REQUIRE(!runtime.IsRunning());
+    REQUIRE(platform->initialize_calls == 1);
+    REQUIRE(platform->teardown_calls == 1);
+    REQUIRE(window->create_calls == 1);
+    REQUIRE(window->teardown_calls == 0);
+}
+
+void TestStopRetriesPlatformTeardownAfterStartupRollbackFailure() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kGui;
+    policy.rendering_enabled = true;
+
+    auto platform = std::make_shared<FakePlatformHost>();
+    auto window = std::make_shared<FakeWindowHost>();
+    platform->teardown_result = false;
+    window->create_result = false;
+
+    framekit::runtime::PlatformHostRuntime runtime;
+    runtime.SetPlatformHost(platform);
+    runtime.SetWindowHost(window);
+    REQUIRE(runtime.Configure(policy));
+    REQUIRE(!runtime.Start());
+    REQUIRE(runtime.LastError().find("platform teardown failed after startup failure") != std::string::npos);
+    REQUIRE(!runtime.IsRunning());
+    REQUIRE(!runtime.Start());
+    REQUIRE(runtime.LastError().find("cleanup is required") != std::string::npos);
+
+    platform->teardown_result = true;
+    REQUIRE(runtime.Stop());
+    REQUIRE(platform->initialize_calls == 1);
+    REQUIRE(platform->teardown_calls == 2);
 }
 
 void TestTickFailsOnPlatformPumpFailure() {
@@ -247,6 +298,8 @@ int main() {
     TestHeadlessRuntimeSkipsWindowStages();
     TestStartFailsWithoutPlatformHost();
     TestStartFailsWhenRenderStagesActiveWithoutWindowHost();
+    TestStartFailureOnWindowCreateTeardownsPlatform();
+    TestStopRetriesPlatformTeardownAfterStartupRollbackFailure();
     TestTickFailsOnPlatformPumpFailure();
     TestTickRenderFailureDegradesThenEscalates();
     TestDeterministicHostRenderFailureFailsFastImmediately();


### PR DESCRIPTION
## Summary
- harden PlatformHostRuntime startup rollback when render startup fails after platform initialization
- preserve cleanup state when rollback teardown fails so Stop can retry before restart
- align Cocoa support wording and stable v2 contract docs with the validated release baseline

## Validation
- cmake -S . -B ~/.copilot/session-state/d57a0d8e-764c-4325-a91f-ba9a6cdbd1fa/framekit-hardening-build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_COCOA=OFF
- cmake --build ~/.copilot/session-state/d57a0d8e-764c-4325-a91f-ba9a6cdbd1fa/framekit-hardening-build --parallel
- ctest --test-dir ~/.copilot/session-state/d57a0d8e-764c-4325-a91f-ba9a6cdbd1fa/framekit-hardening-build --output-on-failure
- cmake -S . -B ~/.copilot/session-state/d57a0d8e-764c-4325-a91f-ba9a6cdbd1fa/framekit-hardening-cocoa-build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_COCOA=ON
- cmake --build ~/.copilot/session-state/d57a0d8e-764c-4325-a91f-ba9a6cdbd1fa/framekit-hardening-cocoa-build --parallel
- ctest --test-dir ~/.copilot/session-state/d57a0d8e-764c-4325-a91f-ba9a6cdbd1fa/framekit-hardening-cocoa-build --output-on-failure

Refs #151