### PR TITLE
chore(release): prepare v2.1.0

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -83,10 +83,10 @@ jobs:
         run: cmake --build build
 
       - name: Test
-        run: ctest --test-dir build --output-on-failure -LE example-launch
+        run: ctest --test-dir build --output-on-failure -LE integration-example
 
-      - name: Launch examples (macOS)
-        run: ctest --test-dir build --output-on-failure -L example-launch
+      - name: Launch integration examples
+        run: ctest --test-dir build --output-on-failure -L integration-example
 
   framekit-with-netkit-macos:
     name: netkit-shmpipe-macos
@@ -109,7 +109,10 @@ jobs:
         run: cmake --build build
 
       - name: Test
-        run: ctest --test-dir build --output-on-failure
+        run: ctest --test-dir build --output-on-failure -LE example-launch
+
+      - name: Launch examples (macOS)
+        run: ctest --test-dir build --output-on-failure -L integration-example
 
   sanitizer-linux:
     name: sanitizer-linux-clang

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -57,12 +57,10 @@ jobs:
         run: cmake --build build
 
       - name: Test
-        run: ctest --test-dir build --output-on-failure
+        run: ctest --test-dir build --output-on-failure -LE example-launch
 
       - name: Launch examples (macOS)
-        run: |
-          ./build/framekit_single_process_example
-          ./build/framekit_multi_worker_example
+        run: ctest --test-dir build --output-on-failure -L example-launch
 
   framekit-with-netkit:
     name: netkit-shmpipe
@@ -85,7 +83,10 @@ jobs:
         run: cmake --build build
 
       - name: Test
-        run: ctest --test-dir build --output-on-failure
+        run: ctest --test-dir build --output-on-failure -LE example-launch
+
+      - name: Launch examples (macOS)
+        run: ctest --test-dir build --output-on-failure -L example-launch
 
   framekit-with-netkit-macos:
     name: netkit-shmpipe-macos

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -51,13 +51,18 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure
-        run: cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF -DCMAKE_BUILD_TYPE=Release
+        run: cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=OFF -DFRAMEKIT_ENABLE_COCOA=ON -DCMAKE_BUILD_TYPE=Release
 
       - name: Build
         run: cmake --build build
 
       - name: Test
         run: ctest --test-dir build --output-on-failure
+
+      - name: Launch examples (macOS)
+        run: |
+          ./build/framekit_single_process_example
+          ./build/framekit_multi_worker_example
 
   framekit-with-netkit:
     name: netkit-shmpipe
@@ -97,7 +102,7 @@ jobs:
           path: netkit
 
       - name: Configure
-        run: cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=ON -DFRAMEKIT_NETKIT_SOURCE_DIR=${{ github.workspace }}/netkit -DCMAKE_BUILD_TYPE=Release
+        run: cmake -S . -B build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_NETKIT=ON -DFRAMEKIT_ENABLE_COCOA=ON -DFRAMEKIT_NETKIT_SOURCE_DIR=${{ github.workspace }}/netkit -DCMAKE_BUILD_TYPE=Release
 
       - name: Build
         run: cmake --build build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 - Release-evidence updates for the `v2.0.0` promotion flow.
+- Hardened platform startup cleanup when window creation fails after platform initialization.
+- Aligned Cocoa support wording and core v2 contract documentation status with the validated release baseline.
 
 ## v2.0.0
 - First public release of the rewritten, incompatible FrameKit v2 line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
 ## Unreleased
-- Release-evidence updates for the `v2.0.0` promotion flow.
-- Hardened platform startup cleanup when window creation fails after platform initialization.
-- Aligned Cocoa support wording and core v2 contract documentation status with the validated release baseline.
+
+## v2.1.0 - 2026-06-05
+- Added opt-in dynamic module loader contract surfaces, load/unload decision helpers, and rollback planning helpers.
+- Added execution service registry contracts, task submission semantics, scheduler policy metrics, and a non-gating execution benchmark harness.
+- Added composition guidance and NetKit-backed example validation hooks.
+- Added CI-validated macOS Cocoa launch checks and promoted Cocoa backend support documentation to supported opt-in status.
+- Hardened service teardown, external-owned service registration behavior, and platform startup rollback cleanup.
+- Aligned release evidence, Cocoa support wording, and core v2 contract documentation status with the validated release baseline.
 
 ## v2.0.0
 - First public release of the rewritten, incompatible FrameKit v2 line.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,20 @@ if(FRAMEKIT_ENABLE_NETKIT)
             examples/frontend_backend/backend_main.cpp
         )
         target_link_libraries(framekit_backend_example PRIVATE FrameKit::Core NetKit::Transport)
+
+        if(FRAMEKIT_BUILD_TESTS)
+            add_test(NAME framekit_example_launch_frontend
+                COMMAND framekit_frontend_example
+            )
+            add_test(NAME framekit_example_launch_backend
+                COMMAND framekit_backend_example
+            )
+            set_tests_properties(
+                framekit_example_launch_frontend
+                framekit_example_launch_backend
+                PROPERTIES LABELS "integration-example;example-launch;integration;netkit"
+            )
+        endif()
     elseif(FRAMEKIT_BUILD_EXAMPLES)
         message(WARNING "FRAMEKIT_ENABLE_NETKIT=ON but NetKit::Transport was not found; skipping netkit examples")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,21 @@ project(framekit VERSION 2.0.0 LANGUAGES C CXX)
 option(FRAMEKIT_BUILD_TESTS "Build framekit tests" ON)
 option(FRAMEKIT_BUILD_EXAMPLES "Build framekit examples" ON)
 option(FRAMEKIT_ENABLE_NETKIT "Enable NetKit-dependent framekit integrations" OFF)
+option(FRAMEKIT_ENABLE_COCOA "Enable experimental macOS Cocoa backend support" OFF)
 
 set(FRAMEKIT_NETKIT_SOURCE_DIR "" CACHE PATH "Path to netkit source directory")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(FRAMEKIT_ENABLE_COCOA AND NOT APPLE)
+    message(FATAL_ERROR "FRAMEKIT_ENABLE_COCOA is only supported on macOS")
+endif()
+
+if(FRAMEKIT_ENABLE_COCOA)
+    enable_language(OBJCXX)
+endif()
 
 add_library(framekit_core STATIC
     src/multiprocess_runtime.cpp
@@ -25,6 +34,16 @@ add_library(framekit_core STATIC
     src/bootstrap_services.cpp
     src/kernel_runtime.cpp
 )
+
+if(FRAMEKIT_ENABLE_COCOA)
+    target_sources(framekit_core PRIVATE
+        src/cocoa_platform_backend.mm
+    )
+else()
+    target_sources(framekit_core PRIVATE
+        src/platform_backend_factory_stub.cpp
+    )
+endif()
 add_library(FrameKit::Core ALIAS framekit_core)
 
 target_include_directories(framekit_core
@@ -34,6 +53,13 @@ target_include_directories(framekit_core
 )
 
 target_compile_features(framekit_core PUBLIC cxx_std_20)
+
+if(FRAMEKIT_ENABLE_COCOA)
+    target_link_libraries(framekit_core PRIVATE "-framework AppKit")
+    target_compile_options(framekit_core PRIVATE
+        $<$<COMPILE_LANGUAGE:OBJCXX>:-fobjc-arc>
+    )
+endif()
 
 if(FRAMEKIT_BUILD_EXAMPLES)
     add_executable(framekit_single_process_example

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,10 @@ if(FRAMEKIT_ENABLE_COCOA)
     )
 endif()
 
+if(FRAMEKIT_BUILD_TESTS)
+    enable_testing()
+endif()
+
 if(FRAMEKIT_BUILD_EXAMPLES)
     add_executable(framekit_single_process_example
         examples/single_process/main.cpp
@@ -71,6 +75,20 @@ if(FRAMEKIT_BUILD_EXAMPLES)
         examples/multi_worker/main.cpp
     )
     target_link_libraries(framekit_multi_worker_example PRIVATE FrameKit::Core)
+
+    if(FRAMEKIT_BUILD_TESTS AND APPLE AND FRAMEKIT_ENABLE_COCOA)
+        add_test(NAME framekit_example_launch_single_process
+            COMMAND framekit_single_process_example
+        )
+        add_test(NAME framekit_example_launch_multi_worker
+            COMMAND framekit_multi_worker_example
+        )
+        set_tests_properties(
+            framekit_example_launch_single_process
+            framekit_example_launch_multi_worker
+            PROPERTIES LABELS "example-launch;platform;cocoa"
+        )
+    endif()
 endif()
 
 if(FRAMEKIT_ENABLE_NETKIT)
@@ -99,6 +117,5 @@ if(FRAMEKIT_ENABLE_NETKIT)
 endif()
 
 if(FRAMEKIT_BUILD_TESTS)
-    enable_testing()
     add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.23)
 
-project(framekit VERSION 2.0.0 LANGUAGES C CXX)
+project(framekit VERSION 2.1.0 LANGUAGES C CXX)
 
 option(FRAMEKIT_BUILD_TESTS "Build framekit tests" ON)
 option(FRAMEKIT_BUILD_EXAMPLES "Build framekit examples" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(framekit VERSION 2.0.0 LANGUAGES C CXX)
 option(FRAMEKIT_BUILD_TESTS "Build framekit tests" ON)
 option(FRAMEKIT_BUILD_EXAMPLES "Build framekit examples" ON)
 option(FRAMEKIT_ENABLE_NETKIT "Enable NetKit-dependent framekit integrations" OFF)
-option(FRAMEKIT_ENABLE_COCOA "Enable experimental macOS Cocoa backend support" OFF)
+option(FRAMEKIT_ENABLE_COCOA "Enable macOS Cocoa backend support" OFF)
 
 set(FRAMEKIT_NETKIT_SOURCE_DIR "" CACHE PATH "Path to netkit source directory")
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Modular C/C++ application framework focused on single-process and multiprocess a
 - A runtime framework for building frontend/backend/worker style apps.
 - A contracts-first core where transport implementations can be optional.
 - A host for integrations with `netkit` and `mediakit`.
-- A window backend contract with an Apple Cocoa module implementation.
+- A window backend contract with experimental Apple Cocoa support on macOS.
 
 ## Multiprocess Direction
 `framekit` owns multiprocess orchestration contracts and runtime behavior. Transport implementations are optional and supplied by `netkit`.
@@ -47,7 +47,7 @@ Core sample executables:
 - `framekit_single_process_example`
 - `framekit_multi_worker_example`
 
-Apple Cocoa backend module:
+Experimental Apple Cocoa backend (local/macOS only until dedicated validation lands):
 ```bash
 cmake -S . -B build \
   -DFRAMEKIT_BUILD_TESTS=ON \
@@ -55,6 +55,10 @@ cmake -S . -B build \
   -DFRAMEKIT_ENABLE_COCOA=ON
 cmake --build build
 ```
+
+When enabled on macOS, `PlatformHostRuntime` auto-wires Cocoa platform/window
+hosts for GUI and Hybrid render-active usage if no hosts are injected
+explicitly.
 
 ## Attribution Request
 If you use FrameKit in your project, please mention FrameKit and credit George Gil / TinMan in your project documentation.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Modular C/C++ application framework focused on single-process and multiprocess a
 - A runtime framework for building frontend/backend/worker style apps.
 - A contracts-first core where transport implementations can be optional.
 - A host for integrations with `netkit` and `mediakit`.
-- A window backend contract with experimental Apple Cocoa support on macOS.
+- A window backend contract with CI-validated Apple Cocoa support on macOS.
 
 ## Multiprocess Direction
 `framekit` owns multiprocess orchestration contracts and runtime behavior. Transport implementations are optional and supplied by `netkit`.
@@ -47,7 +47,7 @@ Core sample executables:
 - `framekit_single_process_example`
 - `framekit_multi_worker_example`
 
-Experimental Apple Cocoa backend (local/macOS only until dedicated validation lands):
+Apple Cocoa backend (macOS only, opt-in):
 ```bash
 cmake -S . -B build \
   -DFRAMEKIT_BUILD_TESTS=ON \

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## FrameKit v2.0.0
 
-Status: Draft
+Status: Published
 Last Updated: 2026-03-29
 
 ### Summary
@@ -27,5 +27,5 @@ It replaces the earlier baseline with a contracts-first, incompatible release.
 
 - CI expansion issue: #107
 - Release cutover issue: #108
-- Release promotion PR: pending
-- Signed tag: pending
+- Release promotion PR: #111
+- Signed tag: v2.0.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,45 @@
 # Release Notes
 
+## FrameKit v2.1.0
+
+Status: Published
+Last Updated: 2026-06-05
+
+### Summary
+
+FrameKit v2.1.0 promotes the post-v2.0.0 stabilization and additive contract
+work now validated on `develop`.
+
+This release keeps the v2 contracts source-compatible while adding optional
+execution-service, scheduler-metrics, dynamic-module decision, integration, and
+platform-validation surfaces.
+
+### Highlights
+
+- Added dynamic module loader contract surfaces for manifests, load/unload
+  decision evaluation, and rollback planning without enabling default runtime
+  dynamic loading.
+- Added execution service registry contracts, task submission semantics,
+  scheduler policy metrics, and a non-gating benchmark harness.
+- Added composition guidance and NetKit-backed example validation hooks.
+- Added CI-validated macOS Cocoa launch checks and documented Cocoa as supported
+  opt-in backend support.
+- Hardened service teardown, external-owned service registration behavior, and
+  platform startup rollback cleanup.
+
+### Compatibility
+
+- FrameKit v2.1.0 is source-compatible with the v2.0.0 public baseline.
+- New dynamic-loading and execution-service surfaces are additive and opt-in.
+- Runtime dynamic module loading remains intentionally inactive unless future
+  integration work wires it into a host.
+
+### Release Evidence
+
+- Release tracking issue: #153
+- Promotion PR: release/v2.1.0 -> master
+- Signed tag: v2.1.0
+
 ## FrameKit v2.0.0
 
 Status: Published

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -37,7 +37,7 @@ platform-validation surfaces.
 ### Release Evidence
 
 - Release tracking issue: #153
-- Promotion PR: release/v2.1.0 -> master
+- Promotion PR: #154
 - Signed tag: v2.1.0
 
 ## FrameKit v2.0.0

--- a/docs/adr/ADR-0002-module-loading-model.md
+++ b/docs/adr/ADR-0002-module-loading-model.md
@@ -29,3 +29,4 @@ Dynamic loading remains optional future work and is out of baseline scope.
 ## Related Docs
 
 - [Module Contract and Dependency DAG Semantics](../module-contract-dag-semantics.md)
+- [Post-Release Roadmap (2026-03-29)](../doctrine/post-release-roadmap-2026-03-29.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,7 +1,7 @@
 # Architecture Decision Records (ADRs)
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,7 @@
 - [FrameKit v2 Charter](charter-v2.md)
 - [External Integration Boundary Contract](integration-boundary.md)
 - [FrameKit v2 Stable Contract Inventory](v2-stable-contracts.md)
+- [Platform Support Matrix](platform-support-matrix.md)
 - [Lifecycle and Shutdown Semantics](lifecycle-semantics.md)
 - [Loop Stage Graph and Profile/Policy Specification](loop-stage-graph-profiles.md)
 - [Module Contract and Dependency DAG Semantics](module-contract-dag-semantics.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,7 @@
 - [External Integration Boundary Contract](integration-boundary.md)
 - [FrameKit v2 Stable Contract Inventory](v2-stable-contracts.md)
 - [Platform Support Matrix](platform-support-matrix.md)
+- [Composition Matrix](composition-matrix.md)
 - [Lifecycle and Shutdown Semantics](lifecycle-semantics.md)
 - [Loop Stage Graph and Profile/Policy Specification](loop-stage-graph-profiles.md)
 - [Module Contract and Dependency DAG Semantics](module-contract-dag-semantics.md)

--- a/docs/charter-v2.md
+++ b/docs/charter-v2.md
@@ -1,7 +1,7 @@
 # FrameKit v2 Charter
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/composition-matrix.md
+++ b/docs/composition-matrix.md
@@ -50,8 +50,8 @@ external runtime repositories.
 - Core composition paths validate with FrameKit CI build/test coverage.
 - Cocoa-enabled macOS paths validate launch checks through CTest `example-launch`
   labels.
-- NetKit-backed examples validate by enabling NetKit and building/running the
-  frontend/backend examples.
+- NetKit-backed examples validate through CTest `integration-example` labels in
+  NetKit-enabled CI jobs.
 
 ## Boundary Alignment
 

--- a/docs/composition-matrix.md
+++ b/docs/composition-matrix.md
@@ -1,0 +1,63 @@
+# Composition Matrix
+
+Status: Stable
+Last Reviewed: 2026-03-30
+
+## Purpose
+
+Define the supported composition modes for integrating FrameKit with optional
+runtime dependencies while preserving the external integration boundary.
+
+## Composition Modes
+
+| Mode | Build options | Example binaries | Primary use |
+| --- | --- | --- | --- |
+| Single-process host | `FRAMEKIT_ENABLE_NETKIT=OFF` | `framekit_single_process_example` | Local deterministic host lifecycle with no external transport dependency |
+| Multiprocess host (local launcher) | `FRAMEKIT_ENABLE_NETKIT=OFF` | `framekit_multi_worker_example` | Parent + worker topology and liveness semantics without external IPC runtime |
+| Multiprocess host + transport-backed integration | `FRAMEKIT_ENABLE_NETKIT=ON` and `FRAMEKIT_NETKIT_SOURCE_DIR=<path>` | `framekit_frontend_example`, `framekit_backend_example` | Composition boundary where FrameKit host contracts coordinate with NetKit transport adapters |
+
+## Bridge Module Patterns
+
+Bridge modules live in composition applications, not FrameKit core and not
+external runtime repositories.
+
+### 1) Lifecycle Bridge
+
+- Convert app startup intent into `ApplicationSpec` and runtime configuration.
+- Own startup/shutdown ordering for FrameKit host and external runtime startup.
+- Keep fallback and retry behavior in composition code rather than FrameKit.
+
+### 2) Service Bridge
+
+- Register integration-facing services in scoped service context.
+- Expose minimal host-facing interfaces rather than runtime concrete types.
+- Teardown external resources through composition-owned shutdown hooks.
+
+### 3) Event Bridge
+
+- Translate runtime-native events into FrameKit event bus payloads.
+- Keep domain payload schemas and event typing outside FrameKit contracts.
+- Map subscription boundaries in composition modules only.
+
+### 4) Transport Bridge
+
+- Select transport kind through application configuration.
+- Bind runtime transport factories and endpoint naming in composition wiring.
+- Keep transport-specific diagnostics and adaptation logic outside FrameKit core.
+
+## Validation Expectations
+
+- Core composition paths validate with FrameKit CI build/test coverage.
+- Cocoa-enabled macOS paths validate launch checks through CTest `example-launch`
+  labels.
+- NetKit-backed examples validate by enabling NetKit and building/running the
+  frontend/backend examples.
+
+## Boundary Alignment
+
+This matrix is constrained by the
+[External Integration Boundary Contract](integration-boundary.md):
+
+- FrameKit remains domain-agnostic.
+- External runtime repositories remain FrameKit-independent.
+- Composition behavior is implemented only in integration applications.

--- a/docs/doctrine/README.md
+++ b/docs/doctrine/README.md
@@ -13,6 +13,7 @@ The canonical source remains the Doctrine repository.
 - [Doctrine Governance](doctrine-governance.md)
 - [Project Board Workflow](project-board-workflow.md)
 - [Phase 0 Sign-Off Checklist and Implementation Gate](phase0-signoff-gate.md)
+- [Post-Release Roadmap (2026-03-29)](post-release-roadmap-2026-03-29.md)
 
 ## Refresh
 

--- a/docs/doctrine/dynamic-module-loader-contract-2026-03-30.md
+++ b/docs/doctrine/dynamic-module-loader-contract-2026-03-30.md
@@ -20,8 +20,11 @@ Primary contract types:
 - `DynamicModuleDecision`
 - `DynamicModuleRefusalReason`
 - `DynamicModuleLoadState`
+- `DynamicLoaderHostPhase`
 - `IDynamicModuleLoader`
 - `ValidateDynamicModuleManifest(...)`
+- `EvaluateDynamicLoadRequest(...)`
+- `EvaluateDynamicUnloadRequest(...)`
 
 ## Baseline Rules
 
@@ -37,6 +40,8 @@ Primary contract types:
 - No runtime behavior change is introduced for static baseline startup/shutdown.
 - Dynamic loading remains opt-in and inactive unless a future slice wires
   runtime integration hooks.
+- Load/unload decision helpers provide deterministic refusal reasons without
+  mutating baseline startup/shutdown behavior.
 
 ## Follow-up Slices
 

--- a/docs/doctrine/dynamic-module-loader-contract-2026-03-30.md
+++ b/docs/doctrine/dynamic-module-loader-contract-2026-03-30.md
@@ -1,0 +1,45 @@
+# Dynamic Module Loader Contract (2026-03-30)
+
+Status: Draft
+Last Reviewed: 2026-03-30
+
+## Purpose
+
+Define the first opt-in contract surface for post-release dynamic module
+loading work in track #113 without enabling runtime dynamic loading by default.
+
+## Contract Surface
+
+Header:
+
+- `include/framekit/module/dynamic_loader.hpp`
+
+Primary contract types:
+
+- `DynamicModuleManifest`
+- `DynamicModuleDecision`
+- `DynamicModuleRefusalReason`
+- `DynamicModuleLoadState`
+- `IDynamicModuleLoader`
+- `ValidateDynamicModuleManifest(...)`
+
+## Baseline Rules
+
+- Manifest `module_id` and `module_version` must be non-empty.
+- Required and optional dependency entries must be non-empty.
+- A module cannot depend on itself.
+- Dependency entries must be unique within each list.
+- A dependency cannot appear in both required and optional lists.
+
+## Safety Position
+
+- This slice introduces contract shapes and deterministic validation only.
+- No runtime behavior change is introduced for static baseline startup/shutdown.
+- Dynamic loading remains opt-in and inactive unless a future slice wires
+  runtime integration hooks.
+
+## Follow-up Slices
+
+- Runtime load/unload state integration and refusal semantics.
+- Rollback/fault handling for partial dynamic load failures.
+- Explicit unload restrictions and dependency-safe refusal paths.

--- a/docs/doctrine/dynamic-module-loader-contract-2026-03-30.md
+++ b/docs/doctrine/dynamic-module-loader-contract-2026-03-30.md
@@ -25,6 +25,8 @@ Primary contract types:
 - `ValidateDynamicModuleManifest(...)`
 - `EvaluateDynamicLoadRequest(...)`
 - `EvaluateDynamicUnloadRequest(...)`
+- `BuildDynamicRollbackPlan(...)`
+- `AssessDynamicRollbackResult(...)`
 
 ## Baseline Rules
 
@@ -48,3 +50,10 @@ Primary contract types:
 - Runtime load/unload state integration and refusal semantics.
 - Rollback/fault handling for partial dynamic load failures.
 - Explicit unload restrictions and dependency-safe refusal paths.
+
+## Rollback Planning Notes
+
+- `BuildDynamicRollbackPlan(...)` derives deterministic reverse-order unload
+  steps for partially loaded dynamic modules.
+- `AssessDynamicRollbackResult(...)` classifies rollback success/failure to
+  support future fault escalation logic.

--- a/docs/doctrine/execution-service-benchmark-baseline-2026-03-30.md
+++ b/docs/doctrine/execution-service-benchmark-baseline-2026-03-30.md
@@ -1,0 +1,60 @@
+# Execution Service Benchmark Baseline (2026-03-30)
+
+Status: Stable
+Last Reviewed: 2026-03-30
+
+## Purpose
+
+Provide a repeatable, non-gating benchmark harness for the baseline execution
+service contract introduced in scheduler roadmap track #114.
+
+This benchmark is advisory. It does not gate CI and should be interpreted as a
+relative signal across local reruns on the same machine.
+
+## Harness
+
+Executable target:
+
+- `framekit_execution_service_benchmark`
+
+Source:
+
+- `tests/test_execution_service_benchmark.cpp`
+
+Workload:
+
+- queue `N` tasks into `InlineExecutionService`
+- drain all queued tasks
+- verify completion states and checksum integrity
+- print submit/drain timings and execution metrics
+
+## Run Command
+
+```bash
+cmake -S . -B build-benchmark -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build-benchmark --target framekit_execution_service_benchmark
+./build-benchmark/tests/framekit_execution_service_benchmark 100000
+```
+
+## Sample Output (Local)
+
+```text
+execution-service benchmark
+task_count=100000
+submit_ms=7
+drain_ms=4
+metrics.submitted=100000
+metrics.completed=100000
+metrics.failed=0
+metrics.cancelled=0
+metrics.rejected=0
+```
+
+## Interpretation Guidance
+
+- `submit_ms` tracks queue insertion overhead.
+- `drain_ms` tracks inline execution throughput.
+- Any non-zero `failed`, `cancelled`, or `rejected` values in this workload are
+  unexpected and should be investigated.
+- Compare against prior runs on the same machine/configuration for trend
+  analysis rather than absolute cross-machine comparisons.

--- a/docs/doctrine/post-release-roadmap-2026-03-29.md
+++ b/docs/doctrine/post-release-roadmap-2026-03-29.md
@@ -1,0 +1,165 @@
+# FrameKit v2 Post-Release Roadmap
+
+Status: Stable
+Last Reviewed: 2026-03-29
+
+## Purpose
+
+Record the post-release follow-up map for the FrameKit v2 line after the
+published `v2.0.0` release. This roadmap closes planning issues #113, #114,
+#115, and #116 by defining the concrete work sequence, dependencies, and
+validation expectations for each track without starting implementation.
+
+## Track Summary
+
+| Issue | Track | Outcome |
+| --- | --- | --- |
+| #113 | Optional dynamic module loading | Define the opt-in loader contract, runtime hooks, and safety rules before any implementation work starts. |
+| #114 | Scheduler and execution services | Additive execution-service and scheduling work scoped to flexible v2 areas only. |
+| #115 | Platform expansion and Cocoa validation | Fold existing deferred Cocoa work into one sequenced backend and validation plan. |
+| #116 | Ecosystem integration and composition | Expand composition examples and guidance without coupling FrameKit to external runtimes. |
+
+## Recommended Execution Order
+
+1. Platform expansion and Cocoa validation (`#115`)
+2. Ecosystem integration and composition (`#116`)
+3. Scheduler and execution services (`#114`)
+4. Optional dynamic module loading (`#113`)
+
+Rationale:
+
+- Platform and integration work provide real validation pressure on the v2
+  contracts before more invasive extensibility work begins.
+- Scheduler work should be informed by actual integration and runtime needs.
+- Dynamic loading carries the highest compatibility and lifecycle risk and
+  should remain last until the static baseline has more downstream proof.
+
+## Track #113: Optional Dynamic Module Loading
+
+### Constraints
+
+- Follow the deferred future-work path in [ADR-0002](../adr/ADR-0002-module-loading-model.md).
+- Remain opt-in and additive within the flexible-area rules in
+  [FrameKit v2 Stable Contract Inventory](../v2-stable-contracts.md).
+- Preserve deterministic startup and shutdown guarantees from the static
+  baseline.
+
+### Follow-Up Sequence
+
+1. Define the loader-facing contract surface:
+   module identity, manifest shape, discovery model, and explicit opt-in
+   registration hooks.
+2. Specify runtime integration points:
+   load timing, service registration window, module graph validation, and
+   failure/rollback behavior.
+3. Define lifecycle safety rules:
+   legal load states, unload restrictions, dependency refusal semantics, and
+   fault escalation on invalid operations.
+4. Add contract tests and a minimal example host that exercises load, refusal,
+   and unload edge cases.
+5. Update ADRs and user-facing documentation only after the contract shape is
+   proven by tests.
+
+### Validation Expectations
+
+- Deterministic startup/shutdown behavior remains unchanged when dynamic
+  loading is disabled.
+- Runtime load failures do not leave the module graph or service context in a
+  partially committed state.
+- Unload rules are explicit and test-covered for dependency and lifecycle
+  violations.
+
+## Track #114: Scheduler and Execution Services
+
+### Constraints
+
+- Keep the work additive and backward-compatible within the flexible-area
+  rules in [FrameKit v2 Stable Contract Inventory](../v2-stable-contracts.md).
+- Do not alter frozen loop-stage ordering or baseline lifecycle semantics.
+
+### Follow-Up Sequence
+
+1. Define the execution-service abstraction exposed to applications and modules,
+   including registration, ownership, and shutdown guarantees.
+2. Specify task submission semantics:
+   queue ownership, cancellation boundaries, result delivery, and fault
+   propagation.
+3. Introduce scheduler policy variants as optional adapters:
+   single-threaded baseline, fixed pool, and stage-affine execution.
+4. Add observability hooks for queue depth, latency, starvation, and budget
+   tracking.
+5. Add validation coverage:
+   unit tests for semantics, integration tests for shutdown/fault cases, and
+   benchmark baselines for representative workloads.
+
+### Validation Expectations
+
+- Applications that do not opt into execution services preserve current
+  deterministic behavior.
+- Scheduler-enabled modes have explicit fault and shutdown guarantees.
+- Benchmarks and tests demonstrate no regression in baseline single-threaded
+  operation.
+
+## Track #115: Platform Expansion and Cocoa Validation
+
+### Constraints
+
+- Fold existing deferred Cocoa issues #33 and #34 into one sequenced platform
+  track instead of creating duplicate planning work.
+- Keep backend implementation details behind the existing minimal platform
+  contract.
+
+### Follow-Up Sequence
+
+1. Audit issue #33 and issue #34 against the current v2 platform/window
+   contract and confirm which gaps remain relevant after `v2.0.0`.
+2. Define the backend delivery slices:
+   adapter implementation, event pump integration, and render hook behavior.
+3. Define CI/runtime validation requirements for macOS:
+   compile coverage, sample launch coverage, and behavior checks that prove the
+   backend matches current host semantics.
+4. Update the support matrix and platform docs once the backend and validation
+   path are real.
+
+### Validation Expectations
+
+- macOS backend behavior is validated against the same lifecycle, input, and
+  event-routing guarantees as other supported hosts.
+- CI coverage proves the backend still builds and examples still launch on
+  macOS after future changes.
+
+## Track #116: Ecosystem Integration and Composition
+
+### Constraints
+
+- Preserve the separation rules in [External Integration Boundary Contract](../integration-boundary.md).
+- Keep FrameKit domain-agnostic and avoid compile-time dependency on external
+  runtimes such as NodeX or MediaKit.
+
+### Follow-Up Sequence
+
+1. Define the composition-example matrix:
+   single-process host, multiprocess host, and optional transport-backed
+   integration example expectations.
+2. Document bridge-module patterns for lifecycle, services, events, and
+   transport handoff without embedding domain semantics into FrameKit.
+3. Expand example and guide coverage for selective linking, NetKit-enabled
+   paths, and service-boundary composition.
+4. Add validation expectations for examples:
+   build coverage, launch coverage, and documentation consistency checks.
+
+### Validation Expectations
+
+- Example applications remain composition-only and do not introduce circular
+  dependencies with external repos.
+- Integration guidance stays aligned with the current boundary contract and
+  selective-linking rules.
+
+## Completion Criteria
+
+This roadmap is complete when:
+
+- Each track has a sequenced implementation map.
+- Dependencies and validation expectations are explicit.
+- No post-release track is started until it is intentionally moved out of
+  backlog and into active issue execution.

--- a/docs/error-policy-matrix.md
+++ b/docs/error-policy-matrix.md
@@ -1,7 +1,7 @@
 # Error Policy Matrix by Loop Profile
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/event-input-semantics.md
+++ b/docs/event-input-semantics.md
@@ -1,7 +1,7 @@
 # Event and Input Semantics Contract
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/integration-boundary.md
+++ b/docs/integration-boundary.md
@@ -60,3 +60,7 @@ repositories remain FrameKit-independent.
 
 NodeX is an example domain runtime system used to validate this boundary.
 The same separation rules apply to any external runtime.
+
+Companion integration guidance:
+
+- [Composition Matrix](composition-matrix.md)

--- a/docs/integration-boundary.md
+++ b/docs/integration-boundary.md
@@ -1,7 +1,7 @@
 # External Integration Boundary Contract
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/lifecycle-semantics.md
+++ b/docs/lifecycle-semantics.md
@@ -1,7 +1,7 @@
 # Lifecycle and Shutdown Semantics
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/loop-stage-graph-profiles.md
+++ b/docs/loop-stage-graph-profiles.md
@@ -1,7 +1,7 @@
 # Loop Stage Graph and Profile/Policy Specification
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/module-contract-dag-semantics.md
+++ b/docs/module-contract-dag-semantics.md
@@ -1,7 +1,7 @@
 # Module Contract and Dependency DAG Semantics
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -26,5 +26,6 @@ Public include layout is organized by concern under `include/framekit/`:
 - `spec/`, `lifecycle/`, `loop/`, `platform/`, `input/`, `event/`, `module/`, `service/`, `fault/`, `kernel/`, `multiprocess/`, and `ipc/`
 
 For v2 scope and boundaries, see the [FrameKit v2 Charter](charter-v2.md).
+For platform support and validation pathways, see the [Platform Support Matrix](platform-support-matrix.md).
 For latest contract-drift evidence and remediation traceability, see the [API/Docs Contract Alignment Audit (2026-03-29)](doctrine/api-doc-contract-alignment-2026-03-29.md).
 For the sequenced post-release backlog after `v2.0.0`, see the [Post-Release Roadmap (2026-03-29)](doctrine/post-release-roadmap-2026-03-29.md).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -17,6 +17,11 @@ Current baseline includes:
 - event bus immediate/deferred dispatch baseline with consume and priority semantics
 - selective-linking guidance for optional module usage
 
+Platform validation coverage includes:
+- Linux and macOS CMake build + contract test coverage in CI
+- macOS Cocoa backend validation in CI with `FRAMEKIT_ENABLE_COCOA=ON`
+- deterministic macOS launch checks for `framekit_single_process_example` and `framekit_multi_worker_example`
+
 Public include layout is organized by concern under `include/framekit/`:
 - `spec/`, `lifecycle/`, `loop/`, `platform/`, `input/`, `event/`, `module/`, `service/`, `fault/`, `kernel/`, `multiprocess/`, and `ipc/`
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -28,5 +28,6 @@ Public include layout is organized by concern under `include/framekit/`:
 For v2 scope and boundaries, see the [FrameKit v2 Charter](charter-v2.md).
 For platform support and validation pathways, see the [Platform Support Matrix](platform-support-matrix.md).
 For integration composition modes and bridge-module patterns, see the [Composition Matrix](composition-matrix.md).
+For scheduler benchmark baseline guidance, see the [Execution Service Benchmark Baseline (2026-03-30)](doctrine/execution-service-benchmark-baseline-2026-03-30.md).
 For latest contract-drift evidence and remediation traceability, see the [API/Docs Contract Alignment Audit (2026-03-29)](doctrine/api-doc-contract-alignment-2026-03-29.md).
 For the sequenced post-release backlog after `v2.0.0`, see the [Post-Release Roadmap (2026-03-29)](doctrine/post-release-roadmap-2026-03-29.md).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -29,5 +29,6 @@ For v2 scope and boundaries, see the [FrameKit v2 Charter](charter-v2.md).
 For platform support and validation pathways, see the [Platform Support Matrix](platform-support-matrix.md).
 For integration composition modes and bridge-module patterns, see the [Composition Matrix](composition-matrix.md).
 For scheduler benchmark baseline guidance, see the [Execution Service Benchmark Baseline (2026-03-30)](doctrine/execution-service-benchmark-baseline-2026-03-30.md).
+For optional dynamic-loading contract surface details, see the [Dynamic Module Loader Contract (2026-03-30)](doctrine/dynamic-module-loader-contract-2026-03-30.md).
 For latest contract-drift evidence and remediation traceability, see the [API/Docs Contract Alignment Audit (2026-03-29)](doctrine/api-doc-contract-alignment-2026-03-29.md).
 For the sequenced post-release backlog after `v2.0.0`, see the [Post-Release Roadmap (2026-03-29)](doctrine/post-release-roadmap-2026-03-29.md).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -27,5 +27,6 @@ Public include layout is organized by concern under `include/framekit/`:
 
 For v2 scope and boundaries, see the [FrameKit v2 Charter](charter-v2.md).
 For platform support and validation pathways, see the [Platform Support Matrix](platform-support-matrix.md).
+For integration composition modes and bridge-module patterns, see the [Composition Matrix](composition-matrix.md).
 For latest contract-drift evidence and remediation traceability, see the [API/Docs Contract Alignment Audit (2026-03-29)](doctrine/api-doc-contract-alignment-2026-03-29.md).
 For the sequenced post-release backlog after `v2.0.0`, see the [Post-Release Roadmap (2026-03-29)](doctrine/post-release-roadmap-2026-03-29.md).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -22,3 +22,4 @@ Public include layout is organized by concern under `include/framekit/`:
 
 For v2 scope and boundaries, see the [FrameKit v2 Charter](charter-v2.md).
 For latest contract-drift evidence and remediation traceability, see the [API/Docs Contract Alignment Audit (2026-03-29)](doctrine/api-doc-contract-alignment-2026-03-29.md).
+For the sequenced post-release backlog after `v2.0.0`, see the [Post-Release Roadmap (2026-03-29)](doctrine/post-release-roadmap-2026-03-29.md).

--- a/docs/platform-support-matrix.md
+++ b/docs/platform-support-matrix.md
@@ -1,0 +1,25 @@
+# Platform Support Matrix
+
+This matrix documents the currently supported host targets and the validation paths that gate changes.
+
+## Runtime/Backend Matrix
+
+| Host platform | Platform backend path | Status | Primary validation path |
+| --- | --- | --- | --- |
+| Linux | Stub/manual host injection (`platform_backend_factory_stub.cpp`) | Supported | `CI (C++ / CMake)` Linux jobs: configure, build, and contract tests |
+| macOS | Cocoa backend (`cocoa_platform_backend.mm`) with `FRAMEKIT_ENABLE_COCOA=ON` | Supported | `CI (C++ / CMake)` macOS jobs: configure/build, contract tests, and `example-launch` CTest checks |
+
+## Validation Notes
+
+- Cocoa backend support is opt-in via `FRAMEKIT_ENABLE_COCOA=ON`.
+- Example runtime launch checks are codified as CTest cases:
+  - `framekit_example_launch_single_process`
+  - `framekit_example_launch_multi_worker`
+- macOS CI executes launch validation through CTest labels:
+  - contract/runtime suite: `ctest --test-dir build --output-on-failure -LE example-launch`
+  - launch checks: `ctest --test-dir build --output-on-failure -L example-launch`
+
+## Scope Boundaries
+
+- This matrix describes FrameKit host/runtime validation only.
+- Optional NetKit/MediaKit integrations remain composition-level and are tracked separately from host backend support.

--- a/docs/selective_linking.md
+++ b/docs/selective_linking.md
@@ -1,6 +1,8 @@
 # Selective Linking Guide
 
 FrameKit supports optional linkage. You only link modules you explicitly enable.
+For composition-mode mapping and bridge responsibilities, see the
+[Composition Matrix](composition-matrix.md).
 
 ## 1) FrameKit core only (no NetKit)
 ```bash
@@ -32,3 +34,15 @@ Check linked libraries of your app:
 - Windows: `dumpbin /dependents <binary>`
 
 If NetKit is disabled, your FrameKit binaries should not link NetKit artifacts.
+
+## Composition Validation Paths
+
+- Single-process host validation:
+  - build with `FRAMEKIT_ENABLE_NETKIT=OFF`
+  - run `framekit_single_process_example`
+- Multiprocess host validation:
+  - build with `FRAMEKIT_ENABLE_NETKIT=OFF`
+  - run `framekit_multi_worker_example`
+- Transport-backed integration validation:
+  - build with `FRAMEKIT_ENABLE_NETKIT=ON`
+  - run `framekit_frontend_example` and `framekit_backend_example`

--- a/docs/selective_linking.md
+++ b/docs/selective_linking.md
@@ -45,4 +45,4 @@ If NetKit is disabled, your FrameKit binaries should not link NetKit artifacts.
   - run `framekit_multi_worker_example`
 - Transport-backed integration validation:
   - build with `FRAMEKIT_ENABLE_NETKIT=ON`
-  - run `framekit_frontend_example` and `framekit_backend_example`
+  - run `ctest --test-dir build --output-on-failure -L integration-example`

--- a/docs/service-context-contract-freeze.md
+++ b/docs/service-context-contract-freeze.md
@@ -1,7 +1,7 @@
 # Service Context Contract and Freeze Policy
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/docs/v2-stable-contracts.md
+++ b/docs/v2-stable-contracts.md
@@ -1,7 +1,7 @@
 # FrameKit v2 Stable Contract Inventory
 
-Status: Draft
-Last Reviewed: 2026-03-29
+Status: Stable
+Last Reviewed: 2026-06-05
 
 ## Purpose
 

--- a/include/framekit/framekit.hpp
+++ b/include/framekit/framekit.hpp
@@ -35,6 +35,7 @@
 #include "framekit/service/context.hpp"
 #include "framekit/service/execution.hpp"
 #include "framekit/service/bootstrap.hpp"
+#include "framekit/module/dynamic_loader.hpp"
 #include "framekit/module/graph.hpp"
 
 // Multiprocess support contracts.

--- a/include/framekit/framekit.hpp
+++ b/include/framekit/framekit.hpp
@@ -33,6 +33,7 @@
 
 // Services and module graph.
 #include "framekit/service/context.hpp"
+#include "framekit/service/execution.hpp"
 #include "framekit/service/bootstrap.hpp"
 #include "framekit/module/graph.hpp"
 

--- a/include/framekit/module/dynamic_loader.hpp
+++ b/include/framekit/module/dynamic_loader.hpp
@@ -50,6 +50,18 @@ struct DynamicModuleDecision {
     std::string message;
 };
 
+struct DynamicModuleRollbackPlan {
+    bool required = false;
+    std::string failed_module_id;
+    std::vector<std::string> unload_order;
+};
+
+struct DynamicModuleRollbackResult {
+    bool success = true;
+    std::size_t unload_failures = 0;
+    std::vector<std::string> failed_unloads;
+};
+
 class IDynamicModuleLoader {
 public:
     virtual ~IDynamicModuleLoader() = default;
@@ -135,6 +147,51 @@ inline DynamicModuleDecision EvaluateDynamicUnloadRequest(
         .accepted = true,
         .refusal_reason = DynamicModuleRefusalReason::kNone,
         .message = "unload accepted",
+    };
+}
+
+inline DynamicModuleRollbackPlan BuildDynamicRollbackPlan(
+    const std::vector<std::string>& loaded_modules_in_order,
+    std::string_view failed_module_id) {
+    DynamicModuleRollbackPlan plan;
+    plan.failed_module_id = std::string(failed_module_id);
+
+    if (failed_module_id.empty()) {
+        return plan;
+    }
+
+    auto it = std::find(
+        loaded_modules_in_order.begin(),
+        loaded_modules_in_order.end(),
+        failed_module_id);
+    if (it == loaded_modules_in_order.end()) {
+        return plan;
+    }
+
+    plan.required = true;
+    for (auto reverse = loaded_modules_in_order.rbegin(); reverse != loaded_modules_in_order.rend(); ++reverse) {
+        plan.unload_order.push_back(*reverse);
+        if (*reverse == failed_module_id) {
+            break;
+        }
+    }
+
+    return plan;
+}
+
+inline DynamicModuleDecision AssessDynamicRollbackResult(const DynamicModuleRollbackResult& rollback_result) {
+    if (rollback_result.success && rollback_result.unload_failures == 0 && rollback_result.failed_unloads.empty()) {
+        return DynamicModuleDecision{
+            .accepted = true,
+            .refusal_reason = DynamicModuleRefusalReason::kNone,
+            .message = "rollback succeeded",
+        };
+    }
+
+    return DynamicModuleDecision{
+        .accepted = false,
+        .refusal_reason = DynamicModuleRefusalReason::kIllegalLifecycleState,
+        .message = "rollback left modules in a partially loaded state",
     };
 }
 

--- a/include/framekit/module/dynamic_loader.hpp
+++ b/include/framekit/module/dynamic_loader.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+
+namespace framekit::runtime {
+
+enum class DynamicModuleRefusalReason : std::uint8_t {
+    kNone = 0,
+    kInvalidManifest = 1,
+    kDuplicateModuleId = 2,
+    kDependencyUnavailable = 3,
+    kIllegalLifecycleState = 4,
+    kUnloadNotAllowed = 5,
+};
+
+enum class DynamicModuleLoadState : std::uint8_t {
+    kDiscovered = 0,
+    kRegistered = 1,
+    kLoaded = 2,
+    kStarted = 3,
+    kRefused = 4,
+    kUnloaded = 5,
+};
+
+struct DynamicModuleManifest {
+    std::string module_id;
+    std::string module_version;
+    std::vector<std::string> required_dependencies;
+    std::vector<std::string> optional_dependencies;
+    std::vector<std::string> exported_services;
+    bool hot_unload_allowed = false;
+};
+
+struct DynamicModuleDecision {
+    bool accepted = false;
+    DynamicModuleRefusalReason refusal_reason = DynamicModuleRefusalReason::kNone;
+    std::string message;
+};
+
+class IDynamicModuleLoader {
+public:
+    virtual ~IDynamicModuleLoader() = default;
+
+    virtual DynamicModuleDecision RegisterManifest(const DynamicModuleManifest& manifest) = 0;
+    virtual DynamicModuleDecision LoadModule(std::string_view module_id) = 0;
+    virtual DynamicModuleDecision UnloadModule(std::string_view module_id) = 0;
+};
+
+inline bool ValidateDynamicModuleManifest(const DynamicModuleManifest& manifest, std::string* error) {
+    auto fail = [error](std::string message) {
+        if (error) {
+            *error = std::move(message);
+        }
+        return false;
+    };
+
+    if (manifest.module_id.empty()) {
+        return fail("module manifest id must be non-empty");
+    }
+
+    if (manifest.module_version.empty()) {
+        return fail("module manifest version must be non-empty");
+    }
+
+    if (manifest.required_dependencies.empty() && manifest.optional_dependencies.empty()) {
+        return true;
+    }
+
+    std::unordered_set<std::string> required_set;
+    required_set.reserve(manifest.required_dependencies.size());
+    for (const auto& dependency : manifest.required_dependencies) {
+        if (dependency.empty()) {
+            return fail("required dependency id must be non-empty");
+        }
+        if (dependency == manifest.module_id) {
+            return fail("module manifest cannot require itself");
+        }
+        if (!required_set.insert(dependency).second) {
+            return fail("required dependency list contains duplicate entries");
+        }
+    }
+
+    std::unordered_set<std::string> optional_set;
+    optional_set.reserve(manifest.optional_dependencies.size());
+    for (const auto& dependency : manifest.optional_dependencies) {
+        if (dependency.empty()) {
+            return fail("optional dependency id must be non-empty");
+        }
+        if (dependency == manifest.module_id) {
+            return fail("module manifest cannot optionally depend on itself");
+        }
+        if (!optional_set.insert(dependency).second) {
+            return fail("optional dependency list contains duplicate entries");
+        }
+        if (required_set.find(dependency) != required_set.end()) {
+            return fail("dependency cannot be both required and optional");
+        }
+    }
+
+    return true;
+}
+
+} // namespace framekit::runtime

--- a/include/framekit/module/dynamic_loader.hpp
+++ b/include/framekit/module/dynamic_loader.hpp
@@ -27,6 +27,14 @@ enum class DynamicModuleLoadState : std::uint8_t {
     kUnloaded = 5,
 };
 
+enum class DynamicLoaderHostPhase : std::uint8_t {
+    kBootstrapping = 0,
+    kInitializing = 1,
+    kRunning = 2,
+    kStopping = 3,
+    kStopped = 4,
+};
+
 struct DynamicModuleManifest {
     std::string module_id;
     std::string module_version;
@@ -50,6 +58,85 @@ public:
     virtual DynamicModuleDecision LoadModule(std::string_view module_id) = 0;
     virtual DynamicModuleDecision UnloadModule(std::string_view module_id) = 0;
 };
+
+inline DynamicModuleDecision EvaluateDynamicLoadRequest(
+    DynamicLoaderHostPhase host_phase,
+    bool module_already_registered,
+    bool dependencies_available) {
+    if (host_phase != DynamicLoaderHostPhase::kRunning) {
+        return DynamicModuleDecision{
+            .accepted = false,
+            .refusal_reason = DynamicModuleRefusalReason::kIllegalLifecycleState,
+            .message = "dynamic loading is only allowed while host phase is running",
+        };
+    }
+
+    if (module_already_registered) {
+        return DynamicModuleDecision{
+            .accepted = false,
+            .refusal_reason = DynamicModuleRefusalReason::kDuplicateModuleId,
+            .message = "module is already registered",
+        };
+    }
+
+    if (!dependencies_available) {
+        return DynamicModuleDecision{
+            .accepted = false,
+            .refusal_reason = DynamicModuleRefusalReason::kDependencyUnavailable,
+            .message = "required dependencies are unavailable",
+        };
+    }
+
+    return DynamicModuleDecision{
+        .accepted = true,
+        .refusal_reason = DynamicModuleRefusalReason::kNone,
+        .message = "load accepted",
+    };
+}
+
+inline DynamicModuleDecision EvaluateDynamicUnloadRequest(
+    DynamicLoaderHostPhase host_phase,
+    const DynamicModuleManifest& manifest,
+    bool module_is_loaded,
+    bool has_runtime_dependents) {
+    if (host_phase != DynamicLoaderHostPhase::kRunning) {
+        return DynamicModuleDecision{
+            .accepted = false,
+            .refusal_reason = DynamicModuleRefusalReason::kIllegalLifecycleState,
+            .message = "dynamic unload is only allowed while host phase is running",
+        };
+    }
+
+    if (!module_is_loaded) {
+        return DynamicModuleDecision{
+            .accepted = false,
+            .refusal_reason = DynamicModuleRefusalReason::kIllegalLifecycleState,
+            .message = "module is not loaded",
+        };
+    }
+
+    if (!manifest.hot_unload_allowed) {
+        return DynamicModuleDecision{
+            .accepted = false,
+            .refusal_reason = DynamicModuleRefusalReason::kUnloadNotAllowed,
+            .message = "module manifest does not allow hot unload",
+        };
+    }
+
+    if (has_runtime_dependents) {
+        return DynamicModuleDecision{
+            .accepted = false,
+            .refusal_reason = DynamicModuleRefusalReason::kDependencyUnavailable,
+            .message = "module has active dependents",
+        };
+    }
+
+    return DynamicModuleDecision{
+        .accepted = true,
+        .refusal_reason = DynamicModuleRefusalReason::kNone,
+        .message = "unload accepted",
+    };
+}
 
 inline bool ValidateDynamicModuleManifest(const DynamicModuleManifest& manifest, std::string* error) {
     auto fail = [error](std::string message) {

--- a/include/framekit/module/graph.hpp
+++ b/include/framekit/module/graph.hpp
@@ -19,6 +19,7 @@ enum class ModuleGraphErrorCode : std::uint8_t {
     kCycleDetected = 3,
     kSelfDependency = 4,
     kDuplicateDependencyEntry = 5,
+    kInvalidModuleId = 6,
 };
 
 struct ModuleGraphError {

--- a/include/framekit/platform/host_runtime.hpp
+++ b/include/framekit/platform/host_runtime.hpp
@@ -74,6 +74,7 @@ private:
     FaultPolicyRuntime fault_policy_;
     bool configured_ = false;
     bool running_ = false;
+    bool platform_initialized_ = false;
     bool window_created_ = false;
     bool frame_failed_ = false;
     bool has_last_tick_timestamp_ = false;

--- a/include/framekit/service/context.hpp
+++ b/include/framekit/service/context.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <stdexcept>
 #include <string>
 #include <typeindex>
 #include <unordered_map>
@@ -67,10 +69,12 @@ public:
         };
 
         std::vector<OrderedEntry> ordered;
+        std::unordered_map<ServiceKey, ServiceEntry, ServiceKeyHasher> external_entries;
         ordered.reserve(entries_.size());
 
         for (const auto& [service_key, entry] : entries_) {
             if (entry.ownership != ServiceOwnership::kContextOwned) {
+                external_entries.emplace(service_key, entry);
                 continue;
             }
 
@@ -98,7 +102,7 @@ public:
             });
         }
 
-        entries_.clear();
+        entries_ = std::move(external_entries);
         return true;
     }
 
@@ -124,7 +128,8 @@ public:
         return entries_.size();
     }
 
-    const std::vector<ServiceTeardownRecord>& LastTeardownOrder() const {
+    std::vector<ServiceTeardownRecord> LastTeardownOrder() const {
+        std::shared_lock lock(mutex_);
         return last_teardown_order_;
     }
 

--- a/include/framekit/service/context.hpp
+++ b/include/framekit/service/context.hpp
@@ -161,11 +161,18 @@ public:
             sequence = existing->second.sequence;
         }
 
-        entries_[std::move(service_key)] = ServiceEntry{
-            .instance = std::static_pointer_cast<void>(std::move(service)),
+        auto storage = ServiceEntry{
             .ownership = ownership,
             .sequence = sequence,
         };
+
+        if (ownership == ServiceOwnership::kExternalOwned) {
+            storage.external_instance = std::static_pointer_cast<void>(service);
+        } else {
+            storage.instance = std::static_pointer_cast<void>(std::move(service));
+        }
+
+        entries_[std::move(service_key)] = std::move(storage);
 
         return true;
     }
@@ -181,6 +188,10 @@ public:
         const auto found = entries_.find(service_key);
         if (found == entries_.end()) {
             return nullptr;
+        }
+
+        if (found->second.ownership == ServiceOwnership::kExternalOwned) {
+            return std::static_pointer_cast<T>(found->second.external_instance.lock());
         }
 
         return std::static_pointer_cast<T>(found->second.instance);
@@ -215,6 +226,7 @@ private:
 
     struct ServiceEntry {
         std::shared_ptr<void> instance;
+        std::weak_ptr<void> external_instance;
         ServiceOwnership ownership = ServiceOwnership::kContextOwned;
         std::size_t sequence = 0;
     };

--- a/include/framekit/service/execution.hpp
+++ b/include/framekit/service/execution.hpp
@@ -1,0 +1,231 @@
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace framekit::runtime {
+
+enum class ExecutionServicePhase : std::uint8_t {
+    kOpen = 0,
+    kFrozen = 1,
+    kShuttingDown = 2,
+};
+
+enum class ExecutionServiceOwnership : std::uint8_t {
+    kContextOwned = 0,
+    kExternalOwned = 1,
+};
+
+struct ExecutionServiceShutdownRecord {
+    std::string key;
+    ExecutionServiceOwnership ownership = ExecutionServiceOwnership::kContextOwned;
+};
+
+class IExecutionService {
+public:
+    virtual ~IExecutionService() = default;
+
+    virtual bool Submit(std::function<void()> task) = 0;
+    virtual bool BeginShutdown() = 0;
+    virtual bool AwaitShutdown(std::chrono::milliseconds timeout) = 0;
+};
+
+class ExecutionServiceRegistry {
+public:
+    ExecutionServiceRegistry() = default;
+
+    ExecutionServicePhase Phase() const {
+        std::shared_lock lock(mutex_);
+        return phase_;
+    }
+
+    bool Freeze() {
+        std::unique_lock lock(mutex_);
+        if (phase_ != ExecutionServicePhase::kOpen) {
+            return false;
+        }
+
+        phase_ = ExecutionServicePhase::kFrozen;
+        freeze_count_ += 1;
+        return true;
+    }
+
+    std::uint64_t FreezeCount() const {
+        std::shared_lock lock(mutex_);
+        return freeze_count_;
+    }
+
+    bool Register(
+        std::shared_ptr<IExecutionService> service,
+        std::string key = {},
+        ExecutionServiceOwnership ownership = ExecutionServiceOwnership::kContextOwned,
+        bool replace_existing = false) {
+        if (!service) {
+            return false;
+        }
+
+        std::unique_lock lock(mutex_);
+        if (phase_ != ExecutionServicePhase::kOpen) {
+            return false;
+        }
+
+        const auto found = entries_.find(key);
+        if (found != entries_.end() && !replace_existing) {
+            return false;
+        }
+
+        std::size_t sequence = registration_sequence_;
+        if (found == entries_.end()) {
+            registration_sequence_ += 1;
+        } else {
+            sequence = found->second.sequence;
+        }
+
+        ServiceEntry entry;
+        entry.ownership = ownership;
+        entry.sequence = sequence;
+        if (ownership == ExecutionServiceOwnership::kExternalOwned) {
+            entry.external_instance = std::move(service);
+        } else {
+            entry.instance = std::move(service);
+        }
+
+        entries_[std::move(key)] = std::move(entry);
+        return true;
+    }
+
+    std::shared_ptr<IExecutionService> Find(std::string key = {}) const {
+        std::shared_lock lock(mutex_);
+        if (phase_ == ExecutionServicePhase::kShuttingDown) {
+            return nullptr;
+        }
+
+        const auto found = entries_.find(key);
+        if (found == entries_.end()) {
+            return nullptr;
+        }
+
+        if (found->second.ownership == ExecutionServiceOwnership::kExternalOwned) {
+            return found->second.external_instance.lock();
+        }
+
+        return found->second.instance;
+    }
+
+    bool BeginShutdown(std::chrono::milliseconds timeout = std::chrono::milliseconds{0}) {
+        std::vector<OrderedEntry> ordered;
+        std::unordered_map<std::string, ServiceEntry> external_entries;
+
+        {
+            std::unique_lock lock(mutex_);
+
+            if (phase_ == ExecutionServicePhase::kShuttingDown) {
+                return true;
+            }
+            if (phase_ != ExecutionServicePhase::kOpen && phase_ != ExecutionServicePhase::kFrozen) {
+                return false;
+            }
+
+            phase_ = ExecutionServicePhase::kShuttingDown;
+
+            ordered.reserve(entries_.size());
+            for (const auto& [key, entry] : entries_) {
+                if (entry.ownership != ExecutionServiceOwnership::kContextOwned) {
+                    external_entries.emplace(key, entry);
+                    continue;
+                }
+
+                ordered.push_back(OrderedEntry{
+                    .key = key,
+                    .instance = entry.instance,
+                    .ownership = entry.ownership,
+                    .sequence = entry.sequence,
+                });
+            }
+
+            std::sort(
+                ordered.begin(),
+                ordered.end(),
+                [](const OrderedEntry& left, const OrderedEntry& right) {
+                    return left.sequence > right.sequence;
+                });
+
+            last_shutdown_order_.clear();
+            for (const auto& item : ordered) {
+                last_shutdown_order_.push_back(ExecutionServiceShutdownRecord{
+                    .key = item.key,
+                    .ownership = item.ownership,
+                });
+            }
+
+            entries_ = external_entries;
+        }
+
+        bool ok = true;
+        for (const auto& item : ordered) {
+            if (!item.instance) {
+                ok = false;
+                continue;
+            }
+
+            ok = item.instance->BeginShutdown() && ok;
+            ok = item.instance->AwaitShutdown(timeout) && ok;
+        }
+
+        return ok;
+    }
+
+    bool ResetForNextStartCycle() {
+        std::unique_lock lock(mutex_);
+        if (phase_ == ExecutionServicePhase::kFrozen) {
+            return false;
+        }
+
+        phase_ = ExecutionServicePhase::kOpen;
+        entries_.clear();
+        registration_sequence_ = 0;
+        return true;
+    }
+
+    std::size_t ServiceCount() const {
+        std::shared_lock lock(mutex_);
+        return entries_.size();
+    }
+
+    std::vector<ExecutionServiceShutdownRecord> LastShutdownOrder() const {
+        std::shared_lock lock(mutex_);
+        return last_shutdown_order_;
+    }
+
+private:
+    struct ServiceEntry {
+        std::shared_ptr<IExecutionService> instance;
+        std::weak_ptr<IExecutionService> external_instance;
+        ExecutionServiceOwnership ownership = ExecutionServiceOwnership::kContextOwned;
+        std::size_t sequence = 0;
+    };
+
+    struct OrderedEntry {
+        std::string key;
+        std::shared_ptr<IExecutionService> instance;
+        ExecutionServiceOwnership ownership = ExecutionServiceOwnership::kContextOwned;
+        std::size_t sequence = 0;
+    };
+
+    mutable std::shared_mutex mutex_;
+    ExecutionServicePhase phase_ = ExecutionServicePhase::kOpen;
+    std::uint64_t freeze_count_ = 0;
+    std::size_t registration_sequence_ = 0;
+    std::unordered_map<std::string, ServiceEntry> entries_;
+    std::vector<ExecutionServiceShutdownRecord> last_shutdown_order_;
+};
+
+} // namespace framekit::runtime

--- a/include/framekit/service/execution.hpp
+++ b/include/framekit/service/execution.hpp
@@ -48,6 +48,27 @@ struct ExecutionTaskResult {
     std::string detail;
 };
 
+enum class SchedulerPolicyKind : std::uint8_t {
+    kSingleThreaded = 0,
+    kFixedPool = 1,
+    kStageAffine = 2,
+};
+
+struct SchedulerPolicyConfig {
+    SchedulerPolicyKind kind = SchedulerPolicyKind::kSingleThreaded;
+    std::size_t worker_count = 1;
+    bool stage_affinity_enabled = false;
+};
+
+struct ExecutionServiceMetrics {
+    std::uint64_t submitted = 0;
+    std::uint64_t rejected = 0;
+    std::uint64_t cancelled = 0;
+    std::uint64_t completed = 0;
+    std::uint64_t failed = 0;
+    std::size_t pending = 0;
+};
+
 class IExecutionService {
 public:
     virtual ~IExecutionService() = default;
@@ -61,6 +82,22 @@ class InlineExecutionService final : public IExecutionService {
 public:
     InlineExecutionService() = default;
 
+    void ConfigurePolicy(SchedulerPolicyConfig policy) {
+        std::unique_lock lock(mutex_);
+        policy_ = std::move(policy);
+        if (policy_.kind == SchedulerPolicyKind::kSingleThreaded) {
+            policy_.worker_count = 1;
+            policy_.stage_affinity_enabled = false;
+        } else if (policy_.worker_count == 0) {
+            policy_.worker_count = 1;
+        }
+    }
+
+    SchedulerPolicyConfig Policy() const {
+        std::shared_lock lock(mutex_);
+        return policy_;
+    }
+
     bool Submit(std::function<void()> task) override {
         const auto result = SubmitTask(std::move(task));
         return result.state == ExecutionTaskState::kQueued;
@@ -70,6 +107,7 @@ public:
         std::unique_lock lock(mutex_);
 
         if (shutting_down_ || !task) {
+            metrics_.rejected += 1;
             return ExecutionTaskResult{
                 .task_id = 0,
                 .state = ExecutionTaskState::kRejected,
@@ -89,6 +127,8 @@ public:
             .detail = "queued",
         };
         results_[task_id] = queued;
+        metrics_.submitted += 1;
+        metrics_.pending = pending_.size();
         return queued;
     }
 
@@ -109,6 +149,8 @@ public:
                 .state = ExecutionTaskState::kCancelled,
                 .detail = "cancelled before execution",
             };
+            metrics_.cancelled += 1;
+            metrics_.pending = pending_.size();
             return true;
         }
 
@@ -120,6 +162,7 @@ public:
         {
             std::unique_lock lock(mutex_);
             to_run.swap(pending_);
+            metrics_.pending = pending_.size();
         }
 
         std::vector<ExecutionTaskResult> drained;
@@ -154,6 +197,11 @@ public:
             {
                 std::unique_lock lock(mutex_);
                 results_[pending.task_id] = outcome;
+                if (outcome.state == ExecutionTaskState::kCompleted) {
+                    metrics_.completed += 1;
+                } else if (outcome.state == ExecutionTaskState::kFailed) {
+                    metrics_.failed += 1;
+                }
             }
             drained.push_back(outcome);
         }
@@ -174,8 +222,10 @@ public:
                 .state = ExecutionTaskState::kCancelled,
                 .detail = "cancelled by shutdown",
             };
+            metrics_.cancelled += 1;
         }
         pending_.clear();
+        metrics_.pending = pending_.size();
         return true;
     }
 
@@ -200,6 +250,11 @@ public:
         return found->second;
     }
 
+    ExecutionServiceMetrics Metrics() const {
+        std::shared_lock lock(mutex_);
+        return metrics_;
+    }
+
 private:
     struct PendingTask {
         ExecutionTaskId task_id = 0;
@@ -208,6 +263,8 @@ private:
 
     mutable std::shared_mutex mutex_;
     bool shutting_down_ = false;
+    SchedulerPolicyConfig policy_;
+    ExecutionServiceMetrics metrics_;
     ExecutionTaskId next_task_id_ = 1;
     std::vector<PendingTask> pending_;
     std::unordered_map<ExecutionTaskId, ExecutionTaskResult> results_;

--- a/include/framekit/service/execution.hpp
+++ b/include/framekit/service/execution.hpp
@@ -3,9 +3,11 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <exception>
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>
@@ -29,6 +31,23 @@ struct ExecutionServiceShutdownRecord {
     ExecutionServiceOwnership ownership = ExecutionServiceOwnership::kContextOwned;
 };
 
+using ExecutionTaskId = std::uint64_t;
+
+enum class ExecutionTaskState : std::uint8_t {
+    kQueued = 0,
+    kRunning = 1,
+    kCompleted = 2,
+    kCancelled = 3,
+    kFailed = 4,
+    kRejected = 5,
+};
+
+struct ExecutionTaskResult {
+    ExecutionTaskId task_id = 0;
+    ExecutionTaskState state = ExecutionTaskState::kRejected;
+    std::string detail;
+};
+
 class IExecutionService {
 public:
     virtual ~IExecutionService() = default;
@@ -36,6 +55,162 @@ public:
     virtual bool Submit(std::function<void()> task) = 0;
     virtual bool BeginShutdown() = 0;
     virtual bool AwaitShutdown(std::chrono::milliseconds timeout) = 0;
+};
+
+class InlineExecutionService final : public IExecutionService {
+public:
+    InlineExecutionService() = default;
+
+    bool Submit(std::function<void()> task) override {
+        const auto result = SubmitTask(std::move(task));
+        return result.state == ExecutionTaskState::kQueued;
+    }
+
+    ExecutionTaskResult SubmitTask(std::function<void()> task) {
+        std::unique_lock lock(mutex_);
+
+        if (shutting_down_ || !task) {
+            return ExecutionTaskResult{
+                .task_id = 0,
+                .state = ExecutionTaskState::kRejected,
+                .detail = shutting_down_ ? "service is shutting down" : "task is empty",
+            };
+        }
+
+        const auto task_id = next_task_id_++;
+        pending_.push_back(PendingTask{
+            .task_id = task_id,
+            .task = std::move(task),
+        });
+
+        const auto queued = ExecutionTaskResult{
+            .task_id = task_id,
+            .state = ExecutionTaskState::kQueued,
+            .detail = "queued",
+        };
+        results_[task_id] = queued;
+        return queued;
+    }
+
+    bool Cancel(ExecutionTaskId task_id) {
+        std::unique_lock lock(mutex_);
+        if (shutting_down_) {
+            return false;
+        }
+
+        for (auto it = pending_.begin(); it != pending_.end(); ++it) {
+            if (it->task_id != task_id) {
+                continue;
+            }
+
+            pending_.erase(it);
+            results_[task_id] = ExecutionTaskResult{
+                .task_id = task_id,
+                .state = ExecutionTaskState::kCancelled,
+                .detail = "cancelled before execution",
+            };
+            return true;
+        }
+
+        return false;
+    }
+
+    std::vector<ExecutionTaskResult> Drain() {
+        std::vector<PendingTask> to_run;
+        {
+            std::unique_lock lock(mutex_);
+            to_run.swap(pending_);
+        }
+
+        std::vector<ExecutionTaskResult> drained;
+        drained.reserve(to_run.size());
+
+        for (auto& pending : to_run) {
+            {
+                std::unique_lock lock(mutex_);
+                results_[pending.task_id] = ExecutionTaskResult{
+                    .task_id = pending.task_id,
+                    .state = ExecutionTaskState::kRunning,
+                    .detail = "running",
+                };
+            }
+
+            ExecutionTaskResult outcome{
+                .task_id = pending.task_id,
+                .state = ExecutionTaskState::kCompleted,
+                .detail = "completed",
+            };
+
+            try {
+                pending.task();
+            } catch (const std::exception& ex) {
+                outcome.state = ExecutionTaskState::kFailed;
+                outcome.detail = ex.what();
+            } catch (...) {
+                outcome.state = ExecutionTaskState::kFailed;
+                outcome.detail = "task threw non-standard exception";
+            }
+
+            {
+                std::unique_lock lock(mutex_);
+                results_[pending.task_id] = outcome;
+            }
+            drained.push_back(outcome);
+        }
+
+        return drained;
+    }
+
+    bool BeginShutdown() override {
+        std::unique_lock lock(mutex_);
+        if (shutting_down_) {
+            return true;
+        }
+
+        shutting_down_ = true;
+        for (const auto& pending : pending_) {
+            results_[pending.task_id] = ExecutionTaskResult{
+                .task_id = pending.task_id,
+                .state = ExecutionTaskState::kCancelled,
+                .detail = "cancelled by shutdown",
+            };
+        }
+        pending_.clear();
+        return true;
+    }
+
+    bool AwaitShutdown(std::chrono::milliseconds timeout) override {
+        (void)timeout;
+        std::shared_lock lock(mutex_);
+        return shutting_down_;
+    }
+
+    std::size_t PendingCount() const {
+        std::shared_lock lock(mutex_);
+        return pending_.size();
+    }
+
+    std::optional<ExecutionTaskResult> FindResult(ExecutionTaskId task_id) const {
+        std::shared_lock lock(mutex_);
+        const auto found = results_.find(task_id);
+        if (found == results_.end()) {
+            return std::nullopt;
+        }
+
+        return found->second;
+    }
+
+private:
+    struct PendingTask {
+        ExecutionTaskId task_id = 0;
+        std::function<void()> task;
+    };
+
+    mutable std::shared_mutex mutex_;
+    bool shutting_down_ = false;
+    ExecutionTaskId next_task_id_ = 1;
+    std::vector<PendingTask> pending_;
+    std::unordered_map<ExecutionTaskId, ExecutionTaskResult> results_;
 };
 
 class ExecutionServiceRegistry {

--- a/src/cocoa_platform_backend.mm
+++ b/src/cocoa_platform_backend.mm
@@ -1,0 +1,136 @@
+#include "platform_backend_factory_internal.hpp"
+
+#import <AppKit/AppKit.h>
+
+namespace framekit::runtime::detail {
+
+namespace {
+
+class CocoaPlatformHost final : public IPlatformHost {
+public:
+    bool Initialize() override {
+        @autoreleasepool {
+            if (![NSThread isMainThread]) {
+                return false;
+            }
+
+            app_ = [NSApplication sharedApplication];
+            if (!app_) {
+                return false;
+            }
+
+            [app_ setActivationPolicy:NSApplicationActivationPolicyRegular];
+            return true;
+        }
+    }
+
+    bool PumpEvents() override {
+        @autoreleasepool {
+            if (!app_) {
+                return false;
+            }
+
+            for (;;) {
+                NSEvent* event = [app_ nextEventMatchingMask:NSEventMaskAny
+                                                   untilDate:[NSDate distantPast]
+                                                      inMode:NSDefaultRunLoopMode
+                                                     dequeue:YES];
+                if (!event) {
+                    break;
+                }
+
+                [app_ sendEvent:event];
+            }
+
+            [app_ updateWindows];
+            return true;
+        }
+    }
+
+    bool Teardown() override {
+        app_ = nil;
+        return true;
+    }
+
+private:
+    NSApplication* __strong app_ = nil;
+};
+
+class CocoaWindowHost final : public IWindowHost {
+public:
+    bool CreatePrimaryWindow(const WindowSpec& spec) override {
+        @autoreleasepool {
+            if (![NSThread isMainThread]) {
+                return false;
+            }
+
+            NSRect frame = NSMakeRect(0.0, 0.0, spec.width, spec.height);
+            NSWindowStyleMask style_mask = NSWindowStyleMaskTitled |
+                NSWindowStyleMaskClosable |
+                NSWindowStyleMaskMiniaturizable |
+                NSWindowStyleMaskResizable;
+
+            window_ = [[NSWindow alloc] initWithContentRect:frame
+                                                  styleMask:style_mask
+                                                    backing:NSBackingStoreBuffered
+                                                      defer:NO];
+            if (!window_) {
+                return false;
+            }
+
+            NSString* title = [NSString stringWithUTF8String:spec.title.c_str()];
+            if (title) {
+                [window_ setTitle:title];
+            }
+
+            if (spec.visible) {
+                [window_ makeKeyAndOrderFront:nil];
+            } else {
+                [window_ orderOut:nil];
+            }
+
+            return true;
+        }
+    }
+
+    bool PreRender() override {
+        return true;
+    }
+
+    bool Render() override {
+        return true;
+    }
+
+    bool PostRender() override {
+        return true;
+    }
+
+    bool TeardownWindows() override {
+        if (window_) {
+            [window_ orderOut:nil];
+            [window_ close];
+            window_ = nil;
+        }
+
+        return true;
+    }
+
+private:
+    NSWindow* __strong window_ = nil;
+};
+
+} // namespace
+
+bool CocoaBackendAvailable() {
+    return true;
+}
+
+std::shared_ptr<IPlatformHost> CreateCocoaPlatformHost() {
+    return std::make_shared<CocoaPlatformHost>();
+}
+
+std::shared_ptr<IWindowHost> CreateCocoaWindowHost() {
+    return std::make_shared<CocoaWindowHost>();
+}
+
+} // namespace framekit::runtime::detail

--- a/src/module_graph.cpp
+++ b/src/module_graph.cpp
@@ -26,7 +26,7 @@ ModuleGraphValidationResult ValidateModuleGraph(const std::vector<ModuleSpec>& m
     for (const auto& module : modules) {
         if (module.id.empty()) {
             return Invalid(ModuleGraphError{
-                .code = ModuleGraphErrorCode::kDuplicateModuleId,
+                .code = ModuleGraphErrorCode::kInvalidModuleId,
                 .module_id = module.id,
                 .dependency_id = {},
                 .message = "module id must be non-empty",

--- a/src/platform_backend_factory_internal.hpp
+++ b/src/platform_backend_factory_internal.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "framekit/platform/host_runtime.hpp"
+
+#include <memory>
+
+namespace framekit::runtime::detail {
+
+bool CocoaBackendAvailable();
+std::shared_ptr<IPlatformHost> CreateCocoaPlatformHost();
+std::shared_ptr<IWindowHost> CreateCocoaWindowHost();
+
+} // namespace framekit::runtime::detail

--- a/src/platform_backend_factory_stub.cpp
+++ b/src/platform_backend_factory_stub.cpp
@@ -1,0 +1,17 @@
+#include "platform_backend_factory_internal.hpp"
+
+namespace framekit::runtime::detail {
+
+bool CocoaBackendAvailable() {
+    return false;
+}
+
+std::shared_ptr<IPlatformHost> CreateCocoaPlatformHost() {
+    return {};
+}
+
+std::shared_ptr<IWindowHost> CreateCocoaWindowHost() {
+    return {};
+}
+
+} // namespace framekit::runtime::detail

--- a/src/platform_host_runtime.cpp
+++ b/src/platform_host_runtime.cpp
@@ -1,8 +1,21 @@
 #include "framekit/platform/host_runtime.hpp"
+#include "platform_backend_factory_internal.hpp"
 
 #include <algorithm>
 
 namespace framekit::runtime {
+
+namespace {
+
+bool EligibleForCocoaAutoWire(const LoopPolicy& policy, bool has_render_stages) {
+    if (!has_render_stages) {
+        return false;
+    }
+
+    return policy.profile == LoopProfile::kGui || policy.profile == LoopProfile::kHybrid;
+}
+
+} // namespace
 
 void PlatformHostRuntime::SetPlatformHost(std::shared_ptr<IPlatformHost> host) {
     platform_host_ = std::move(host);
@@ -183,6 +196,18 @@ bool PlatformHostRuntime::Start() {
         return false;
     }
 
+    const bool has_render_stages = HasActiveRenderStages();
+    const bool can_auto_wire_cocoa =
+        !platform_host_ &&
+        !window_host_ &&
+        EligibleForCocoaAutoWire(policy_, has_render_stages) &&
+        detail::CocoaBackendAvailable();
+
+    if (can_auto_wire_cocoa) {
+        platform_host_ = detail::CreateCocoaPlatformHost();
+        window_host_ = detail::CreateCocoaWindowHost();
+    }
+
     if (!platform_host_) {
         last_error_ = "platform host is required";
         return false;
@@ -193,7 +218,7 @@ bool PlatformHostRuntime::Start() {
         return false;
     }
 
-    if (HasActiveRenderStages()) {
+    if (has_render_stages) {
         if (!window_host_) {
             last_error_ = "window host is required when render stages are active";
             return false;

--- a/src/platform_host_runtime.cpp
+++ b/src/platform_host_runtime.cpp
@@ -36,6 +36,12 @@ bool PlatformHostRuntime::Configure(const LoopPolicy& policy, WindowSpec primary
         return false;
     }
 
+    if (platform_initialized_ || window_created_) {
+        last_error_ = "cannot configure platform runtime while cleanup is pending";
+        configured_ = false;
+        return false;
+    }
+
     if (!loop_runner_.Configure(policy)) {
         last_error_ = loop_runner_.LastError();
         configured_ = false;
@@ -196,6 +202,11 @@ bool PlatformHostRuntime::Start() {
         return false;
     }
 
+    if (platform_initialized_ || window_created_) {
+        last_error_ = "platform runtime cleanup is required before restart";
+        return false;
+    }
+
     const bool has_render_stages = HasActiveRenderStages();
     const bool can_auto_wire_cocoa =
         !platform_host_ &&
@@ -217,16 +228,25 @@ bool PlatformHostRuntime::Start() {
         last_error_ = "platform host initialization failed";
         return false;
     }
+    platform_initialized_ = true;
+
+    auto fail_after_platform_initialize = [this](std::string error) {
+        if (!platform_host_->Teardown()) {
+            error += "; platform teardown failed after startup failure";
+        } else {
+            platform_initialized_ = false;
+        }
+        last_error_ = std::move(error);
+        return false;
+    };
 
     if (has_render_stages) {
         if (!window_host_) {
-            last_error_ = "window host is required when render stages are active";
-            return false;
+            return fail_after_platform_initialize("window host is required when render stages are active");
         }
 
         if (!window_host_->CreatePrimaryWindow(primary_window_)) {
-            last_error_ = "window host failed to create primary window";
-            return false;
+            return fail_after_platform_initialize("window host failed to create primary window");
         }
 
         window_created_ = true;
@@ -268,7 +288,7 @@ bool PlatformHostRuntime::Tick() {
 }
 
 bool PlatformHostRuntime::Stop() {
-    if (!running_) {
+    if (!running_ && !platform_initialized_ && !window_created_) {
         return true;
     }
 
@@ -279,18 +299,21 @@ bool PlatformHostRuntime::Stop() {
             if (last_error_.empty()) {
                 last_error_ = "window host teardown failed";
             }
+        } else {
+            window_created_ = false;
         }
     }
 
-    if (!platform_host_->Teardown()) {
+    if (platform_initialized_ && platform_host_ && !platform_host_->Teardown()) {
         ok = false;
         if (last_error_.empty()) {
             last_error_ = "platform host teardown failed";
         }
+    } else {
+        platform_initialized_ = false;
     }
 
     running_ = false;
-    window_created_ = false;
     frame_failed_ = false;
     has_last_tick_timestamp_ = false;
     return ok;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,3 +48,9 @@ add_executable(framekit_fault_policy_runtime_test
 
 target_link_libraries(framekit_fault_policy_runtime_test PRIVATE FrameKit::Core)
 add_test(NAME framekit_fault_policy_runtime_test COMMAND framekit_fault_policy_runtime_test)
+
+add_executable(framekit_execution_service_benchmark
+    test_execution_service_benchmark.cpp
+)
+
+target_link_libraries(framekit_execution_service_benchmark PRIVATE FrameKit::Core)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,15 @@ add_executable(framekit_platform_host_runtime_test
 target_link_libraries(framekit_platform_host_runtime_test PRIVATE FrameKit::Core)
 add_test(NAME framekit_platform_host_runtime_test COMMAND framekit_platform_host_runtime_test)
 
+if(APPLE AND FRAMEKIT_ENABLE_COCOA)
+    add_executable(framekit_platform_host_runtime_cocoa_test
+        test_platform_host_runtime_cocoa.cpp
+    )
+
+    target_link_libraries(framekit_platform_host_runtime_cocoa_test PRIVATE FrameKit::Core)
+    add_test(NAME framekit_platform_host_runtime_cocoa_test COMMAND framekit_platform_host_runtime_cocoa_test)
+endif()
+
 add_executable(framekit_input_routing_runtime_test
     test_input_routing_runtime.cpp
 )

--- a/tests/test_execution_service_benchmark.cpp
+++ b/tests/test_execution_service_benchmark.cpp
@@ -1,0 +1,80 @@
+#include "framekit/framekit.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+namespace {
+
+std::uint64_t ParsePositiveArg(const char* value, std::uint64_t fallback) {
+    if (!value) {
+        return fallback;
+    }
+
+    try {
+        const auto parsed = std::stoull(value);
+        return parsed == 0 ? fallback : parsed;
+    } catch (...) {
+        return fallback;
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    const std::uint64_t task_count = argc > 1 ? ParsePositiveArg(argv[1], 100000) : 100000;
+
+    framekit::runtime::InlineExecutionService service;
+
+    std::uint64_t checksum = 0;
+    const auto submit_start = std::chrono::steady_clock::now();
+    for (std::uint64_t index = 1; index <= task_count; ++index) {
+        const auto result = service.SubmitTask([&checksum, index]() {
+            checksum += index;
+        });
+        if (result.state != framekit::runtime::ExecutionTaskState::kQueued) {
+            std::cerr << "task submission rejected at index " << index << '\n';
+            return 1;
+        }
+    }
+    const auto submit_end = std::chrono::steady_clock::now();
+
+    const auto drain_start = std::chrono::steady_clock::now();
+    const auto drained = service.Drain();
+    const auto drain_end = std::chrono::steady_clock::now();
+
+    if (drained.size() != task_count) {
+        std::cerr << "unexpected drained task count: " << drained.size() << '\n';
+        return 2;
+    }
+
+    for (const auto& result : drained) {
+        if (result.state != framekit::runtime::ExecutionTaskState::kCompleted) {
+            std::cerr << "task did not complete successfully: id=" << result.task_id << '\n';
+            return 3;
+        }
+    }
+
+    const auto expected_checksum = (task_count * (task_count + 1)) / 2;
+    if (checksum != expected_checksum) {
+        std::cerr << "checksum mismatch: got " << checksum << ", expected " << expected_checksum << '\n';
+        return 4;
+    }
+
+    const auto submit_ms = std::chrono::duration_cast<std::chrono::milliseconds>(submit_end - submit_start).count();
+    const auto drain_ms = std::chrono::duration_cast<std::chrono::milliseconds>(drain_end - drain_start).count();
+
+    const auto metrics = service.Metrics();
+    std::cout << "execution-service benchmark" << '\n';
+    std::cout << "task_count=" << task_count << '\n';
+    std::cout << "submit_ms=" << submit_ms << '\n';
+    std::cout << "drain_ms=" << drain_ms << '\n';
+    std::cout << "metrics.submitted=" << metrics.submitted << '\n';
+    std::cout << "metrics.completed=" << metrics.completed << '\n';
+    std::cout << "metrics.failed=" << metrics.failed << '\n';
+    std::cout << "metrics.cancelled=" << metrics.cancelled << '\n';
+    std::cout << "metrics.rejected=" << metrics.rejected << '\n';
+
+    return 0;
+}

--- a/tests/test_platform_host_runtime.cpp
+++ b/tests/test_platform_host_runtime.cpp
@@ -169,7 +169,58 @@ void TestStartFailsWhenRenderStagesActiveWithoutWindowHost() {
     runtime.SetPlatformHost(platform);
     REQUIRE(runtime.Configure(policy));
     REQUIRE(!runtime.Start());
-    REQUIRE(!runtime.LastError().empty());
+    REQUIRE(runtime.LastError().find("window host is required") != std::string::npos);
+    REQUIRE(!runtime.IsRunning());
+    REQUIRE(platform->initialize_calls == 1);
+    REQUIRE(platform->teardown_calls == 1);
+}
+
+void TestStartFailureOnWindowCreateTeardownsPlatform() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kGui;
+    policy.rendering_enabled = true;
+
+    auto platform = std::make_shared<FakePlatformHost>();
+    auto window = std::make_shared<FakeWindowHost>();
+    window->create_result = false;
+
+    framekit::runtime::PlatformHostRuntime runtime;
+    runtime.SetPlatformHost(platform);
+    runtime.SetWindowHost(window);
+    REQUIRE(runtime.Configure(policy));
+    REQUIRE(!runtime.Start());
+    REQUIRE(runtime.LastError().find("failed to create primary window") != std::string::npos);
+    REQUIRE(!runtime.IsRunning());
+    REQUIRE(platform->initialize_calls == 1);
+    REQUIRE(platform->teardown_calls == 1);
+    REQUIRE(window->create_calls == 1);
+    REQUIRE(window->teardown_calls == 0);
+}
+
+void TestStopRetriesPlatformTeardownAfterStartupRollbackFailure() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kGui;
+    policy.rendering_enabled = true;
+
+    auto platform = std::make_shared<FakePlatformHost>();
+    auto window = std::make_shared<FakeWindowHost>();
+    platform->teardown_result = false;
+    window->create_result = false;
+
+    framekit::runtime::PlatformHostRuntime runtime;
+    runtime.SetPlatformHost(platform);
+    runtime.SetWindowHost(window);
+    REQUIRE(runtime.Configure(policy));
+    REQUIRE(!runtime.Start());
+    REQUIRE(runtime.LastError().find("platform teardown failed after startup failure") != std::string::npos);
+    REQUIRE(!runtime.IsRunning());
+    REQUIRE(!runtime.Start());
+    REQUIRE(runtime.LastError().find("cleanup is required") != std::string::npos);
+
+    platform->teardown_result = true;
+    REQUIRE(runtime.Stop());
+    REQUIRE(platform->initialize_calls == 1);
+    REQUIRE(platform->teardown_calls == 2);
 }
 
 void TestTickFailsOnPlatformPumpFailure() {
@@ -247,6 +298,8 @@ int main() {
     TestHeadlessRuntimeSkipsWindowStages();
     TestStartFailsWithoutPlatformHost();
     TestStartFailsWhenRenderStagesActiveWithoutWindowHost();
+    TestStartFailureOnWindowCreateTeardownsPlatform();
+    TestStopRetriesPlatformTeardownAfterStartupRollbackFailure();
     TestTickFailsOnPlatformPumpFailure();
     TestTickRenderFailureDegradesThenEscalates();
     TestDeterministicHostRenderFailureFailsFastImmediately();

--- a/tests/test_platform_host_runtime_cocoa.cpp
+++ b/tests/test_platform_host_runtime_cocoa.cpp
@@ -1,0 +1,165 @@
+#include "framekit/framekit.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace {
+
+[[noreturn]] void FailRequirement(const char* expr, int line) {
+    std::cerr << "Requirement failed at line " << line << ": " << expr << '\n';
+    std::abort();
+}
+
+#define REQUIRE(expr)            \
+    do {                         \
+        if (!(expr)) {           \
+            FailRequirement(#expr, __LINE__); \
+        }                        \
+    } while (false)
+
+class FakePlatformHost : public framekit::runtime::IPlatformHost {
+public:
+    bool Initialize() override {
+        initialize_calls += 1;
+        return true;
+    }
+
+    bool PumpEvents() override {
+        pump_calls += 1;
+        return true;
+    }
+
+    bool Teardown() override {
+        teardown_calls += 1;
+        return true;
+    }
+
+    int initialize_calls = 0;
+    int pump_calls = 0;
+    int teardown_calls = 0;
+};
+
+class FakeWindowHost : public framekit::runtime::IWindowHost {
+public:
+    bool CreatePrimaryWindow(const framekit::runtime::WindowSpec& spec) override {
+        create_calls += 1;
+        last_title = spec.title;
+        last_visible = spec.visible;
+        return true;
+    }
+
+    bool PreRender() override {
+        pre_render_calls += 1;
+        return true;
+    }
+
+    bool Render() override {
+        render_calls += 1;
+        return true;
+    }
+
+    bool PostRender() override {
+        post_render_calls += 1;
+        return true;
+    }
+
+    bool TeardownWindows() override {
+        teardown_calls += 1;
+        return true;
+    }
+
+    int create_calls = 0;
+    int pre_render_calls = 0;
+    int render_calls = 0;
+    int post_render_calls = 0;
+    int teardown_calls = 0;
+    std::string last_title;
+    bool last_visible = true;
+};
+
+framekit::runtime::LoopPolicy GuiPolicy() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kGui;
+    policy.rendering_enabled = true;
+    return policy;
+}
+
+framekit::runtime::LoopPolicy HybridPolicy() {
+    framekit::runtime::LoopPolicy policy;
+    policy.profile = framekit::runtime::LoopProfile::kHybrid;
+    policy.rendering_enabled = true;
+    return policy;
+}
+
+framekit::runtime::WindowSpec HiddenWindowSpec(std::string title) {
+    framekit::runtime::WindowSpec spec;
+    spec.title = title;
+    spec.visible = false;
+    spec.width = 640;
+    spec.height = 480;
+    return spec;
+}
+
+void TestGuiRuntimeAutoWiresCocoaBackend() {
+    framekit::runtime::PlatformHostRuntime runtime;
+
+    REQUIRE(runtime.Configure(GuiPolicy(), HiddenWindowSpec("framekit-cocoa-gui")));
+    REQUIRE(runtime.Start());
+    REQUIRE(runtime.Tick());
+    REQUIRE(runtime.Stop());
+}
+
+void TestHybridRuntimeAutoWiresCocoaBackend() {
+    framekit::runtime::PlatformHostRuntime runtime;
+
+    REQUIRE(runtime.Configure(HybridPolicy(), HiddenWindowSpec("framekit-cocoa-hybrid")));
+    REQUIRE(runtime.Start());
+    REQUIRE(runtime.Tick());
+    REQUIRE(runtime.Stop());
+}
+
+void TestPartialManualInjectionStillFails() {
+    framekit::runtime::PlatformHostRuntime runtime;
+    runtime.SetPlatformHost(std::make_shared<FakePlatformHost>());
+
+    REQUIRE(runtime.Configure(GuiPolicy(), HiddenWindowSpec("framekit-cocoa-partial")));
+    REQUIRE(!runtime.Start());
+    REQUIRE(runtime.LastError() == "window host is required when render stages are active");
+}
+
+void TestExplicitInjectedHostsStillWin() {
+    auto platform = std::make_shared<FakePlatformHost>();
+    auto window = std::make_shared<FakeWindowHost>();
+
+    framekit::runtime::PlatformHostRuntime runtime;
+    runtime.SetPlatformHost(platform);
+    runtime.SetWindowHost(window);
+
+    REQUIRE(runtime.Configure(GuiPolicy(), HiddenWindowSpec("framekit-manual-hosts")));
+    REQUIRE(runtime.Start());
+    REQUIRE(runtime.Tick());
+    REQUIRE(runtime.Stop());
+
+    REQUIRE(platform->initialize_calls == 1);
+    REQUIRE(platform->pump_calls == 1);
+    REQUIRE(platform->teardown_calls == 1);
+    REQUIRE(window->create_calls == 1);
+    REQUIRE(window->pre_render_calls == 1);
+    REQUIRE(window->render_calls == 1);
+    REQUIRE(window->post_render_calls == 1);
+    REQUIRE(window->teardown_calls == 1);
+    REQUIRE(window->last_title == "framekit-manual-hosts");
+    REQUIRE(!window->last_visible);
+}
+
+} // namespace
+
+int main() {
+    TestGuiRuntimeAutoWiresCocoaBackend();
+    TestHybridRuntimeAutoWiresCocoaBackend();
+    TestPartialManualInjectionStillFails();
+    TestExplicitInjectedHostsStillWin();
+    return 0;
+}

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <any>
+#include <chrono>
 #include <cstdlib>
 #include <iostream>
 #include <memory>
@@ -28,6 +29,38 @@ struct TestService {
 
 struct AlternateService {
     std::string name;
+};
+
+class FakeExecutionService : public framekit::runtime::IExecutionService {
+public:
+    bool Submit(std::function<void()> task) override {
+        submit_calls += 1;
+        if (!accept_submit) {
+            return false;
+        }
+        if (task) {
+            task();
+        }
+        return true;
+    }
+
+    bool BeginShutdown() override {
+        begin_shutdown_calls += 1;
+        return begin_shutdown_result;
+    }
+
+    bool AwaitShutdown(std::chrono::milliseconds timeout) override {
+        (void)timeout;
+        await_shutdown_calls += 1;
+        return await_shutdown_result;
+    }
+
+    int submit_calls = 0;
+    int begin_shutdown_calls = 0;
+    int await_shutdown_calls = 0;
+    bool accept_submit = true;
+    bool begin_shutdown_result = true;
+    bool await_shutdown_result = true;
 };
 
 const char* ModuleLifecyclePhaseName(framekit::runtime::ModuleLifecyclePhase phase) {
@@ -139,6 +172,60 @@ void TestServiceContext() {
     REQUIRE(services.ResetForNextStartCycle());
     REQUIRE(services.Phase() == framekit::runtime::ServiceContextPhase::kOpen);
     REQUIRE(services.ServiceCount() == 0);
+}
+
+void TestExecutionServiceRegistry() {
+    framekit::runtime::ExecutionServiceRegistry registry;
+
+    auto first = std::make_shared<FakeExecutionService>();
+    auto second = std::make_shared<FakeExecutionService>();
+    auto external = std::make_shared<FakeExecutionService>();
+
+    REQUIRE(registry.Register(first, "first"));
+    REQUIRE(!registry.Register(std::make_shared<FakeExecutionService>(), "first"));
+    REQUIRE(registry.Register(second, "second"));
+    REQUIRE(registry.Register(
+        external,
+        "external",
+        framekit::runtime::ExecutionServiceOwnership::kExternalOwned));
+
+    REQUIRE(registry.Freeze());
+    REQUIRE(registry.Phase() == framekit::runtime::ExecutionServicePhase::kFrozen);
+    REQUIRE(registry.FreezeCount() == 1);
+    REQUIRE(!registry.Register(std::make_shared<FakeExecutionService>(), "late"));
+
+    auto found_first = registry.Find("first");
+    REQUIRE(found_first != nullptr);
+    auto found_external = registry.Find("external");
+    REQUIRE(found_external != nullptr);
+
+    found_external.reset();
+    external.reset();
+    REQUIRE(registry.Find("external") == nullptr);
+
+    REQUIRE(registry.BeginShutdown(std::chrono::milliseconds{0}));
+    REQUIRE(registry.Phase() == framekit::runtime::ExecutionServicePhase::kShuttingDown);
+    REQUIRE(registry.Find("first") == nullptr);
+    REQUIRE(first->begin_shutdown_calls == 1);
+    REQUIRE(first->await_shutdown_calls == 1);
+    REQUIRE(second->begin_shutdown_calls == 1);
+    REQUIRE(second->await_shutdown_calls == 1);
+    REQUIRE(registry.ServiceCount() == 1);
+
+    const auto shutdown_order = registry.LastShutdownOrder();
+    REQUIRE(shutdown_order.size() == 2);
+    REQUIRE(shutdown_order[0].key == "second");
+    REQUIRE(shutdown_order[1].key == "first");
+
+    REQUIRE(registry.ResetForNextStartCycle());
+    REQUIRE(registry.Phase() == framekit::runtime::ExecutionServicePhase::kOpen);
+    REQUIRE(registry.ServiceCount() == 0);
+
+    framekit::runtime::ExecutionServiceRegistry failure_registry;
+    auto failure_service = std::make_shared<FakeExecutionService>();
+    failure_service->await_shutdown_result = false;
+    REQUIRE(failure_registry.Register(failure_service, "failure"));
+    REQUIRE(!failure_registry.BeginShutdown(std::chrono::milliseconds{0}));
 }
 
 void TestModuleGraphValidation() {
@@ -473,6 +560,7 @@ int main() {
     TestLifecycleStateMachine();
     TestLoopPolicyValidation();
     TestServiceContext();
+    TestExecutionServiceRegistry();
     TestModuleGraphValidation();
     TestEventBusSemantics();
     TestKernelRuntime();

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -472,6 +472,50 @@ void TestDynamicLoadUnloadDecisionSemantics() {
     REQUIRE(unload_accepted.refusal_reason == framekit::runtime::DynamicModuleRefusalReason::kNone);
 }
 
+void TestDynamicRollbackSemantics() {
+    const std::vector<std::string> loaded_order = {
+        "core",
+        "render",
+        "dynamic-ui",
+    };
+
+    const auto plan = framekit::runtime::BuildDynamicRollbackPlan(loaded_order, "dynamic-ui");
+    REQUIRE(plan.required);
+    REQUIRE(plan.failed_module_id == "dynamic-ui");
+    REQUIRE(plan.unload_order.size() == 1);
+    REQUIRE(plan.unload_order[0] == "dynamic-ui");
+
+    const auto mid_plan = framekit::runtime::BuildDynamicRollbackPlan(loaded_order, "render");
+    REQUIRE(mid_plan.required);
+    REQUIRE(mid_plan.unload_order.size() == 2);
+    REQUIRE(mid_plan.unload_order[0] == "dynamic-ui");
+    REQUIRE(mid_plan.unload_order[1] == "render");
+
+    const auto missing_plan = framekit::runtime::BuildDynamicRollbackPlan(loaded_order, "missing");
+    REQUIRE(!missing_plan.required);
+    REQUIRE(missing_plan.unload_order.empty());
+
+    const auto empty_plan = framekit::runtime::BuildDynamicRollbackPlan(loaded_order, "");
+    REQUIRE(!empty_plan.required);
+
+    const auto rollback_ok = framekit::runtime::AssessDynamicRollbackResult(
+        framekit::runtime::DynamicModuleRollbackResult{
+            .success = true,
+            .unload_failures = 0,
+            .failed_unloads = {},
+        });
+    REQUIRE(rollback_ok.accepted);
+
+    const auto rollback_failed = framekit::runtime::AssessDynamicRollbackResult(
+        framekit::runtime::DynamicModuleRollbackResult{
+            .success = false,
+            .unload_failures = 1,
+            .failed_unloads = {"render"},
+        });
+    REQUIRE(!rollback_failed.accepted);
+    REQUIRE(rollback_failed.refusal_reason == framekit::runtime::DynamicModuleRefusalReason::kIllegalLifecycleState);
+}
+
 void TestEventBusSemantics() {
     framekit::runtime::EventBus bus;
 
@@ -734,6 +778,7 @@ int main() {
     TestModuleGraphValidation();
     TestDynamicModuleManifestValidation();
     TestDynamicLoadUnloadDecisionSemantics();
+    TestDynamicRollbackSemantics();
     TestEventBusSemantics();
     TestKernelRuntime();
     TestKernelRuntimeModuleLifecycleOrchestration();

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -383,6 +383,43 @@ void TestModuleGraphValidation() {
     REQUIRE(invalid_id_result.errors.front().code == framekit::runtime::ModuleGraphErrorCode::kInvalidModuleId);
 }
 
+void TestDynamicModuleManifestValidation() {
+    framekit::runtime::DynamicModuleManifest manifest;
+    manifest.module_id = "dynamic-ui";
+    manifest.module_version = "1.0.0";
+    manifest.required_dependencies = {"core"};
+    manifest.optional_dependencies = {"telemetry"};
+
+    std::string error;
+    REQUIRE(framekit::runtime::ValidateDynamicModuleManifest(manifest, &error));
+    REQUIRE(error.empty());
+
+    framekit::runtime::DynamicModuleManifest empty_id = manifest;
+    empty_id.module_id.clear();
+    REQUIRE(!framekit::runtime::ValidateDynamicModuleManifest(empty_id, &error));
+    REQUIRE(error.find("non-empty") != std::string::npos);
+
+    framekit::runtime::DynamicModuleManifest missing_version = manifest;
+    missing_version.module_version.clear();
+    REQUIRE(!framekit::runtime::ValidateDynamicModuleManifest(missing_version, &error));
+    REQUIRE(error.find("version") != std::string::npos);
+
+    framekit::runtime::DynamicModuleManifest duplicate_required = manifest;
+    duplicate_required.required_dependencies = {"core", "core"};
+    REQUIRE(!framekit::runtime::ValidateDynamicModuleManifest(duplicate_required, &error));
+    REQUIRE(error.find("duplicate") != std::string::npos);
+
+    framekit::runtime::DynamicModuleManifest required_optional_overlap = manifest;
+    required_optional_overlap.optional_dependencies = {"core"};
+    REQUIRE(!framekit::runtime::ValidateDynamicModuleManifest(required_optional_overlap, &error));
+    REQUIRE(error.find("required and optional") != std::string::npos);
+
+    framekit::runtime::DynamicModuleManifest self_dependency = manifest;
+    self_dependency.required_dependencies = {"dynamic-ui"};
+    REQUIRE(!framekit::runtime::ValidateDynamicModuleManifest(self_dependency, &error));
+    REQUIRE(error.find("cannot require itself") != std::string::npos);
+}
+
 void TestEventBusSemantics() {
     framekit::runtime::EventBus bus;
 
@@ -643,6 +680,7 @@ int main() {
     TestExecutionServiceRegistry();
     TestInlineExecutionServiceSemantics();
     TestModuleGraphValidation();
+    TestDynamicModuleManifestValidation();
     TestEventBusSemantics();
     TestKernelRuntime();
     TestKernelRuntimeModuleLifecycleOrchestration();

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -104,8 +104,9 @@ void TestServiceContext() {
 
     REQUIRE(services.Register<TestService>(test_service));
     REQUIRE(!services.Register<TestService>(std::make_shared<TestService>()));
+    auto external_alt = std::make_shared<AlternateService>(AlternateService{"alt"});
     REQUIRE(services.Register<AlternateService>(
-        std::make_shared<AlternateService>(AlternateService{"alt"}),
+        external_alt,
         "alt",
         framekit::runtime::ServiceOwnership::kExternalOwned));
 
@@ -121,6 +122,10 @@ void TestServiceContext() {
     auto alt = services.Find<AlternateService>("alt");
     REQUIRE(alt != nullptr);
     REQUIRE(alt->name == "alt");
+
+    alt.reset();
+    external_alt.reset();
+    REQUIRE(services.Find<AlternateService>("alt") == nullptr);
 
     REQUIRE(services.BeginTeardown());
     REQUIRE(services.Phase() == framekit::runtime::ServiceContextPhase::kTeardown);

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -125,13 +125,15 @@ void TestServiceContext() {
     REQUIRE(services.BeginTeardown());
     REQUIRE(services.Phase() == framekit::runtime::ServiceContextPhase::kTeardown);
     REQUIRE(services.Find<TestService>() == nullptr);
+    REQUIRE(services.ServiceCount() == 1);
 
-    const auto& order = services.LastTeardownOrder();
+    const auto order = services.LastTeardownOrder();
     REQUIRE(order.size() == 1);
     REQUIRE(order.front().contract_type == std::type_index(typeid(TestService)));
 
     REQUIRE(services.ResetForNextStartCycle());
     REQUIRE(services.Phase() == framekit::runtime::ServiceContextPhase::kOpen);
+    REQUIRE(services.ServiceCount() == 0);
 }
 
 void TestModuleGraphValidation() {
@@ -194,6 +196,19 @@ void TestModuleGraphValidation() {
     REQUIRE(!missing_result.valid);
     REQUIRE(!missing_result.errors.empty());
     REQUIRE(missing_result.errors.front().code == framekit::runtime::ModuleGraphErrorCode::kMissingRequiredDependency);
+
+    const std::vector<framekit::runtime::ModuleSpec> invalid_module_id = {
+        framekit::runtime::ModuleSpec{
+            .id = "",
+            .required_dependencies = {},
+            .optional_dependencies = {},
+        },
+    };
+
+    const auto invalid_id_result = framekit::runtime::ValidateModuleGraph(invalid_module_id);
+    REQUIRE(!invalid_id_result.valid);
+    REQUIRE(!invalid_id_result.errors.empty());
+    REQUIRE(invalid_id_result.errors.front().code == framekit::runtime::ModuleGraphErrorCode::kInvalidModuleId);
 }
 
 void TestEventBusSemantics() {

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -420,6 +420,58 @@ void TestDynamicModuleManifestValidation() {
     REQUIRE(error.find("cannot require itself") != std::string::npos);
 }
 
+void TestDynamicLoadUnloadDecisionSemantics() {
+    const auto accepted_load = framekit::runtime::EvaluateDynamicLoadRequest(
+        framekit::runtime::DynamicLoaderHostPhase::kRunning,
+        false,
+        true);
+    REQUIRE(accepted_load.accepted);
+    REQUIRE(accepted_load.refusal_reason == framekit::runtime::DynamicModuleRefusalReason::kNone);
+
+    const auto rejected_phase_load = framekit::runtime::EvaluateDynamicLoadRequest(
+        framekit::runtime::DynamicLoaderHostPhase::kInitializing,
+        false,
+        true);
+    REQUIRE(!rejected_phase_load.accepted);
+    REQUIRE(rejected_phase_load.refusal_reason == framekit::runtime::DynamicModuleRefusalReason::kIllegalLifecycleState);
+
+    const auto duplicate_load = framekit::runtime::EvaluateDynamicLoadRequest(
+        framekit::runtime::DynamicLoaderHostPhase::kRunning,
+        true,
+        true);
+    REQUIRE(!duplicate_load.accepted);
+    REQUIRE(duplicate_load.refusal_reason == framekit::runtime::DynamicModuleRefusalReason::kDuplicateModuleId);
+
+    framekit::runtime::DynamicModuleManifest manifest;
+    manifest.module_id = "dynamic-a";
+    manifest.module_version = "1.0.0";
+
+    const auto unload_not_allowed = framekit::runtime::EvaluateDynamicUnloadRequest(
+        framekit::runtime::DynamicLoaderHostPhase::kRunning,
+        manifest,
+        true,
+        false);
+    REQUIRE(!unload_not_allowed.accepted);
+    REQUIRE(unload_not_allowed.refusal_reason == framekit::runtime::DynamicModuleRefusalReason::kUnloadNotAllowed);
+
+    manifest.hot_unload_allowed = true;
+    const auto unload_has_dependents = framekit::runtime::EvaluateDynamicUnloadRequest(
+        framekit::runtime::DynamicLoaderHostPhase::kRunning,
+        manifest,
+        true,
+        true);
+    REQUIRE(!unload_has_dependents.accepted);
+    REQUIRE(unload_has_dependents.refusal_reason == framekit::runtime::DynamicModuleRefusalReason::kDependencyUnavailable);
+
+    const auto unload_accepted = framekit::runtime::EvaluateDynamicUnloadRequest(
+        framekit::runtime::DynamicLoaderHostPhase::kRunning,
+        manifest,
+        true,
+        false);
+    REQUIRE(unload_accepted.accepted);
+    REQUIRE(unload_accepted.refusal_reason == framekit::runtime::DynamicModuleRefusalReason::kNone);
+}
+
 void TestEventBusSemantics() {
     framekit::runtime::EventBus bus;
 
@@ -681,6 +733,7 @@ int main() {
     TestInlineExecutionServiceSemantics();
     TestModuleGraphValidation();
     TestDynamicModuleManifestValidation();
+    TestDynamicLoadUnloadDecisionSemantics();
     TestEventBusSemantics();
     TestKernelRuntime();
     TestKernelRuntimeModuleLifecycleOrchestration();

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -232,6 +232,29 @@ void TestExecutionServiceRegistry() {
 void TestInlineExecutionServiceSemantics() {
     framekit::runtime::InlineExecutionService service;
 
+    const auto default_policy = service.Policy();
+    REQUIRE(default_policy.kind == framekit::runtime::SchedulerPolicyKind::kSingleThreaded);
+    REQUIRE(default_policy.worker_count == 1);
+
+    service.ConfigurePolicy(framekit::runtime::SchedulerPolicyConfig{
+        .kind = framekit::runtime::SchedulerPolicyKind::kFixedPool,
+        .worker_count = 4,
+        .stage_affinity_enabled = false,
+    });
+    auto fixed_pool = service.Policy();
+    REQUIRE(fixed_pool.kind == framekit::runtime::SchedulerPolicyKind::kFixedPool);
+    REQUIRE(fixed_pool.worker_count == 4);
+
+    service.ConfigurePolicy(framekit::runtime::SchedulerPolicyConfig{
+        .kind = framekit::runtime::SchedulerPolicyKind::kStageAffine,
+        .worker_count = 0,
+        .stage_affinity_enabled = true,
+    });
+    auto stage_affine = service.Policy();
+    REQUIRE(stage_affine.kind == framekit::runtime::SchedulerPolicyKind::kStageAffine);
+    REQUIRE(stage_affine.worker_count == 1);
+    REQUIRE(stage_affine.stage_affinity_enabled);
+
     int executed = 0;
     const auto first = service.SubmitTask([&executed]() { executed += 1; });
     const auto second = service.SubmitTask([&executed]() { executed += 10; });
@@ -239,9 +262,15 @@ void TestInlineExecutionServiceSemantics() {
     REQUIRE(first.state == framekit::runtime::ExecutionTaskState::kQueued);
     REQUIRE(second.state == framekit::runtime::ExecutionTaskState::kQueued);
     REQUIRE(service.PendingCount() == 2);
+    auto metrics = service.Metrics();
+    REQUIRE(metrics.submitted == 2);
+    REQUIRE(metrics.pending == 2);
 
     REQUIRE(service.Cancel(second.task_id));
     REQUIRE(service.PendingCount() == 1);
+    metrics = service.Metrics();
+    REQUIRE(metrics.cancelled == 1);
+    REQUIRE(metrics.pending == 1);
     auto cancelled = service.FindResult(second.task_id);
     REQUIRE(cancelled.has_value());
     REQUIRE(cancelled->state == framekit::runtime::ExecutionTaskState::kCancelled);
@@ -251,6 +280,9 @@ void TestInlineExecutionServiceSemantics() {
     REQUIRE(drained.front().task_id == first.task_id);
     REQUIRE(drained.front().state == framekit::runtime::ExecutionTaskState::kCompleted);
     REQUIRE(executed == 1);
+    metrics = service.Metrics();
+    REQUIRE(metrics.completed == 1);
+    REQUIRE(metrics.pending == 0);
 
     auto completed = service.FindResult(first.task_id);
     REQUIRE(completed.has_value());
@@ -264,12 +296,16 @@ void TestInlineExecutionServiceSemantics() {
     REQUIRE(fault_results.size() == 1);
     REQUIRE(fault_results.front().state == framekit::runtime::ExecutionTaskState::kFailed);
     REQUIRE(fault_results.front().detail == "boom");
+    metrics = service.Metrics();
+    REQUIRE(metrics.failed == 1);
 
     REQUIRE(service.BeginShutdown());
     REQUIRE(service.AwaitShutdown(std::chrono::milliseconds{0}));
 
     const auto rejected = service.SubmitTask([]() {});
     REQUIRE(rejected.state == framekit::runtime::ExecutionTaskState::kRejected);
+    metrics = service.Metrics();
+    REQUIRE(metrics.rejected == 1);
 }
 
 void TestModuleGraphValidation() {

--- a/tests/test_runtime_contract_primitives.cpp
+++ b/tests/test_runtime_contract_primitives.cpp
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -226,6 +227,49 @@ void TestExecutionServiceRegistry() {
     failure_service->await_shutdown_result = false;
     REQUIRE(failure_registry.Register(failure_service, "failure"));
     REQUIRE(!failure_registry.BeginShutdown(std::chrono::milliseconds{0}));
+}
+
+void TestInlineExecutionServiceSemantics() {
+    framekit::runtime::InlineExecutionService service;
+
+    int executed = 0;
+    const auto first = service.SubmitTask([&executed]() { executed += 1; });
+    const auto second = service.SubmitTask([&executed]() { executed += 10; });
+
+    REQUIRE(first.state == framekit::runtime::ExecutionTaskState::kQueued);
+    REQUIRE(second.state == framekit::runtime::ExecutionTaskState::kQueued);
+    REQUIRE(service.PendingCount() == 2);
+
+    REQUIRE(service.Cancel(second.task_id));
+    REQUIRE(service.PendingCount() == 1);
+    auto cancelled = service.FindResult(second.task_id);
+    REQUIRE(cancelled.has_value());
+    REQUIRE(cancelled->state == framekit::runtime::ExecutionTaskState::kCancelled);
+
+    const auto drained = service.Drain();
+    REQUIRE(drained.size() == 1);
+    REQUIRE(drained.front().task_id == first.task_id);
+    REQUIRE(drained.front().state == framekit::runtime::ExecutionTaskState::kCompleted);
+    REQUIRE(executed == 1);
+
+    auto completed = service.FindResult(first.task_id);
+    REQUIRE(completed.has_value());
+    REQUIRE(completed->state == framekit::runtime::ExecutionTaskState::kCompleted);
+
+    const auto faulty = service.SubmitTask([]() {
+        throw std::runtime_error("boom");
+    });
+    REQUIRE(faulty.state == framekit::runtime::ExecutionTaskState::kQueued);
+    const auto fault_results = service.Drain();
+    REQUIRE(fault_results.size() == 1);
+    REQUIRE(fault_results.front().state == framekit::runtime::ExecutionTaskState::kFailed);
+    REQUIRE(fault_results.front().detail == "boom");
+
+    REQUIRE(service.BeginShutdown());
+    REQUIRE(service.AwaitShutdown(std::chrono::milliseconds{0}));
+
+    const auto rejected = service.SubmitTask([]() {});
+    REQUIRE(rejected.state == framekit::runtime::ExecutionTaskState::kRejected);
 }
 
 void TestModuleGraphValidation() {
@@ -561,6 +605,7 @@ int main() {
     TestLoopPolicyValidation();
     TestServiceContext();
     TestExecutionServiceRegistry();
+    TestInlineExecutionServiceSemantics();
     TestModuleGraphValidation();
     TestEventBusSemantics();
     TestKernelRuntime();


### PR DESCRIPTION
## Summary
- bump FrameKit project version to 2.1.0
- move post-v2.0.0 changelog entries into the v2.1.0 release section
- add v2.1.0 release notes for dynamic module contracts, execution services, Cocoa validation, integration validation, and runtime hardening

## Validation
- git diff --check
- cmake -S . -B ~/.copilot/session-state/d57a0d8e-764c-4325-a91f-ba9a6cdbd1fa/framekit-v2.1.0-build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_COCOA=OFF
- cmake --build ~/.copilot/session-state/d57a0d8e-764c-4325-a91f-ba9a6cdbd1fa/framekit-v2.1.0-build --parallel
- ctest --test-dir ~/.copilot/session-state/d57a0d8e-764c-4325-a91f-ba9a6cdbd1fa/framekit-v2.1.0-build --output-on-failure
- cmake -S . -B ~/.copilot/session-state/d57a0d8e-764c-4325-a91f-ba9a6cdbd1fa/framekit-v2.1.0-cocoa-build -DFRAMEKIT_BUILD_TESTS=ON -DFRAMEKIT_BUILD_EXAMPLES=ON -DFRAMEKIT_ENABLE_COCOA=ON
- cmake --build ~/.copilot/session-state/d57a0d8e-764c-4325-a91f-ba9a6cdbd1fa/framekit-v2.1.0-cocoa-build --parallel
- ctest --test-dir ~/.copilot/session-state/d57a0d8e-764c-4325-a91f-ba9a6cdbd1fa/framekit-v2.1.0-cocoa-build --output-on-failure

Refs #153