### PR TITLE
chore(release): back-propagate v2.1.0 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
 ## Unreleased
-- Release-evidence updates for the `v2.0.0` promotion flow.
-- Hardened platform startup cleanup when window creation fails after platform initialization.
-- Aligned Cocoa support wording and core v2 contract documentation status with the validated release baseline.
+
+## v2.1.0 - 2026-06-05
+- Added opt-in dynamic module loader contract surfaces, load/unload decision helpers, and rollback planning helpers.
+- Added execution service registry contracts, task submission semantics, scheduler policy metrics, and a non-gating execution benchmark harness.
+- Added composition guidance and NetKit-backed example validation hooks.
+- Added CI-validated macOS Cocoa launch checks and promoted Cocoa backend support documentation to supported opt-in status.
+- Hardened service teardown, external-owned service registration behavior, and platform startup rollback cleanup.
+- Aligned release evidence, Cocoa support wording, and core v2 contract documentation status with the validated release baseline.
 
 ## v2.0.0
 - First public release of the rewritten, incompatible FrameKit v2 line.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.23)
 
-project(framekit VERSION 2.0.0 LANGUAGES C CXX)
+project(framekit VERSION 2.1.0 LANGUAGES C CXX)
 
 option(FRAMEKIT_BUILD_TESTS "Build framekit tests" ON)
 option(FRAMEKIT_BUILD_EXAMPLES "Build framekit examples" ON)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,45 @@
 # Release Notes
 
+## FrameKit v2.1.0
+
+Status: Published
+Last Updated: 2026-06-05
+
+### Summary
+
+FrameKit v2.1.0 promotes the post-v2.0.0 stabilization and additive contract
+work now validated on `develop`.
+
+This release keeps the v2 contracts source-compatible while adding optional
+execution-service, scheduler-metrics, dynamic-module decision, integration, and
+platform-validation surfaces.
+
+### Highlights
+
+- Added dynamic module loader contract surfaces for manifests, load/unload
+  decision evaluation, and rollback planning without enabling default runtime
+  dynamic loading.
+- Added execution service registry contracts, task submission semantics,
+  scheduler policy metrics, and a non-gating benchmark harness.
+- Added composition guidance and NetKit-backed example validation hooks.
+- Added CI-validated macOS Cocoa launch checks and documented Cocoa as supported
+  opt-in backend support.
+- Hardened service teardown, external-owned service registration behavior, and
+  platform startup rollback cleanup.
+
+### Compatibility
+
+- FrameKit v2.1.0 is source-compatible with the v2.0.0 public baseline.
+- New dynamic-loading and execution-service surfaces are additive and opt-in.
+- Runtime dynamic module loading remains intentionally inactive unless future
+  integration work wires it into a host.
+
+### Release Evidence
+
+- Release tracking issue: #153
+- Promotion PR: release/v2.1.0 -> master
+- Signed tag: v2.1.0
+
 ## FrameKit v2.0.0
 
 Status: Published

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -37,7 +37,7 @@ platform-validation surfaces.
 ### Release Evidence
 
 - Release tracking issue: #153
-- Promotion PR: release/v2.1.0 -> master
+- Promotion PR: #154
 - Signed tag: v2.1.0
 
 ## FrameKit v2.0.0


### PR DESCRIPTION
## Summary
- back-propagate the v2.1.0 project version bump, changelog, and release notes to develop after master promotion

## Validation
- release/v2.1.0 -> master promotion passed required checks
- signed tag v2.1.0 release guard passed
- GitHub release v2.1.0 published

Refs #153